### PR TITLE
Add gotests-vim plugin to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Demo
 
-The following shows `gotests` in action using the [official Sublime Text 3 plugin](https://github.com/cweill/GoTests-Sublime). Plugins also exist for [Emacs](https://github.com/damienlevin/GoTests-Emacs) and [Atom Editor](https://atom.io/packages/gotests).
+The following shows `gotests` in action using the [official Sublime Text 3 plugin](https://github.com/cweill/GoTests-Sublime). Plugins also exist for [Emacs](https://github.com/damienlevin/GoTests-Emacs), [Vim](https://github.com/buoto/gotests-vim) and [Atom Editor](https://atom.io/packages/gotests).
 
 ![demo](https://github.com/cweill/GoTests-Sublime/blob/master/gotests.gif)
 


### PR DESCRIPTION
Since https://github.com/fatih/vim-go/pull/808 got rejected, I've created a small plugin that helps using gotests in Vim. I'm new to vimscript so all suggestions are welcome.

Resolves #20 