### PR TITLE
Don't try to test init functions

### DIFF
--- a/gotests.go
+++ b/gotests.go
@@ -152,12 +152,19 @@ func testableFuncs(funcs []*models.Function, only, excl *regexp.Regexp, exp bool
 	sort.Strings(testFuncs)
 	var fs []*models.Function
 	for _, f := range funcs {
-		if isTestFunction(f, testFuncs) || isExcluded(f, excl) || isUnexported(f, exp) || !isIncluded(f, only) {
+		if isTestFunction(f, testFuncs) || isExcluded(f, excl) || isUnexported(f, exp) || !isIncluded(f, only) || isInvalid(f) {
 			continue
 		}
 		fs = append(fs, f)
 	}
 	return fs
+}
+
+func isInvalid(f *models.Function) bool {
+	if f.Name == "init" && f.IsNaked() {
+		return true
+	}
+	return false
 }
 
 func isTestFunction(f *models.Function, testFuncs []string) bool {

--- a/gotests_test.go
+++ b/gotests_test.go
@@ -503,6 +503,13 @@ func TestGenerateTests(t *testing.T) {
 			},
 			want: mustReadFile(t, "testdata/goldens/subtest_edition_-_functions_and_receivers_with_same_names_except_exporting.go"),
 		},
+		{
+			name: "Init function",
+			args: args{
+				srcPath: `testdata/init_func.go`,
+			},
+			want: mustReadFile(t, "testdata/goldens/no_init_funcs.go"),
+		},
 	}
 	tmp, err := ioutil.TempDir("", "gotests_test")
 	if err != nil {

--- a/testdata/goldens/no_init_funcs.go
+++ b/testdata/goldens/no_init_funcs.go
@@ -1,0 +1,45 @@
+package testdata
+
+import "testing"
+
+func Test_initFuncStruct_init(t *testing.T) {
+	type fields struct {
+		field int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   int
+	}{
+	// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		i := initFuncStruct{
+			field: tt.fields.field,
+		}
+		if got := i.init(); got != tt.want {
+			t.Errorf("%q. initFuncStruct.init() = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func Test_initFieldStruct_getInit(t *testing.T) {
+	type fields struct {
+		init int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   int
+	}{
+	// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		i := initFieldStruct{
+			init: tt.fields.init,
+		}
+		if got := i.getInit(); got != tt.want {
+			t.Errorf("%q. initFieldStruct.getInit() = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}

--- a/testdata/init_func.go
+++ b/testdata/init_func.go
@@ -1,0 +1,30 @@
+package testdata
+
+type initFuncStruct struct {
+	field int
+}
+
+func (i initFuncStruct) init() int {
+	return i.field
+}
+
+type initFieldStruct struct {
+	init int
+}
+
+func (i initFieldStruct) getInit() int {
+	return i.init
+}
+
+var foo1 initFuncStruct
+var foo2 initFieldStruct
+
+func init() {
+	foo1.field = 42
+	foo2.init = 42
+}
+
+func init() {
+	foo1.field = 43
+	foo2.init = 43
+}


### PR DESCRIPTION
There can be multiple init functions per package and they are designed
to be called by the runtime upon inclusion. It makes little sense to attempt
to test them.

Signed-off-by: Robert Beckett <bob.beckett@gmail.com>