### PR TITLE
check map lookup during receiver parsing

### DIFF
--- a/gotests_test.go
+++ b/gotests_test.go
@@ -319,6 +319,12 @@ func TestGenerateTests(t *testing.T) {
 			},
 			want: mustReadFile(t, "testdata/goldens/functions_and_receivers_with_same_names_except_exporting.go"),
 		}, {
+			name: "Receiver is indirect imported struct",
+			args: args{
+				srcPath: `testdata/test037.go`,
+			},
+			want: mustReadFile(t, "testdata/goldens/receiver_is_indirect_imported_struct.go"),
+		}, {
 			name: "Multiple functions",
 			args: args{
 				srcPath: `testdata/test_filter.go`,

--- a/internal/goparser/goparser.go
+++ b/internal/goparser/goparser.go
@@ -217,8 +217,11 @@ func parseReceiver(fl *ast.FieldList, ul map[string]types.Type, el map[*types.St
 	if !ok {
 		return r
 	}
-	st := el[s].(*ast.StructType)
-	r.Fields = append(r.Fields, parseFieldList(st.Fields, ul)...)
+	st, found := el[s]
+	if !found {
+		return r
+	}
+	r.Fields = append(r.Fields, parseFieldList(st.(*ast.StructType).Fields, ul)...)
 	for i, f := range r.Fields {
 		f.Name = s.Field(i).Name()
 	}

--- a/testdata/goldens/receiver_is_indirect_imported_struct.go
+++ b/testdata/goldens/receiver_is_indirect_imported_struct.go
@@ -1,0 +1,16 @@
+package testdata
+
+import "testing"
+
+func Test_someIndirectImportedStruct_Foo037(t *testing.T) {
+	tests := []struct {
+		name string
+		smtg *someIndirectImportedStruct
+	}{
+	// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		smtg := &someIndirectImportedStruct{}
+		smtg.Foo037()
+	}
+}

--- a/testdata/test037.go
+++ b/testdata/test037.go
@@ -1,0 +1,7 @@
+package testdata
+
+import "github.com/cweill/gotests"
+
+type someIndirectImportedStruct gotests.Options
+
+func (smtg *someIndirectImportedStruct) Foo037() {}


### PR DESCRIPTION
This is just a workaround for #49, adding a bit more sanity-checking.