### PR TITLE
Add ability to set a custom template path

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Available options:
   -w           write output to (test) files instead of stdout
   
   -nosubtests  disable subtest generation. Only available for Go 1.7+
+
+  -template_dir  optional. Path to a directory containing custom test code templates
 ```
 
 ## Contributions

--- a/gotests.go
+++ b/gotests.go
@@ -24,6 +24,7 @@ type Options struct {
 	PrintInputs bool                  // Print function parameters in error messages
 	Subtests    bool                  // Print tests using Go 1.7 subtests
 	Importer    func() types.Importer // A custom importer.
+	TemplateDir string                // Path to custom template set
 }
 
 // A GeneratedTest contains information about a test file with generated tests.
@@ -116,6 +117,7 @@ func generateTest(src models.Path, files []models.Path, opt *Options) (*Generate
 	b, err := output.Process(h, funcs, &output.Options{
 		PrintInputs: opt.PrintInputs,
 		Subtests:    opt.Subtests,
+		TemplateDir: opt.TemplateDir,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("output.Process: %v", err)

--- a/gotests/main.go
+++ b/gotests/main.go
@@ -41,6 +41,7 @@ var (
 	allFuncs      = flag.Bool("all", false, "generate tests for all functions and methods")
 	printInputs   = flag.Bool("i", false, "print test inputs in error messages")
 	writeOutput   = flag.Bool("w", false, "write output to (test) files instead of stdout")
+	templateDir  = flag.String("template_dir", "", `optional. Path to a directory containing custom test code templates`)
 )
 
 // nosubtests is always set to default value of true when Go < 1.7.
@@ -60,5 +61,6 @@ func main() {
 		PrintInputs:   *printInputs,
 		Subtests:      !nosubtests,
 		WriteOutput:   *writeOutput,
+		TemplateDir:   *templateDir,
 	})
 }

--- a/gotests/process/process.go
+++ b/gotests/process/process.go
@@ -24,6 +24,7 @@ type Options struct {
 	PrintInputs   bool   // Print function parameters as part of error messages.
 	Subtests      bool   // Print tests using Go 1.7 subtests
 	WriteOutput   bool   // Write output to test file(s).
+	TemplateDir   string // Path to custom template set
 }
 
 // Generates tests for the Go files defined in args with the given options.
@@ -67,6 +68,7 @@ func parseOptions(out io.Writer, opt *Options) *gotests.Options {
 		Exported:    opt.ExportedFuncs,
 		PrintInputs: opt.PrintInputs,
 		Subtests:    opt.Subtests,
+		TemplateDir: opt.TemplateDir,
 	}
 }
 

--- a/gotests_test.go
+++ b/gotests_test.go
@@ -19,6 +19,7 @@ func TestGenerateTests(t *testing.T) {
 		printInputs bool
 		subtests    bool
 		importer    types.Importer
+		templateDir string
 	}
 	tests := []struct {
 		name              string
@@ -542,6 +543,32 @@ func TestGenerateTests(t *testing.T) {
 			},
 			want: mustReadFile(t, "testdata/goldens/existing_test_file_with_package_level_comments.go"),
 		},
+		{
+			name: "Test non existing template path",
+			args: args{
+				srcPath:     `testdata/calculator.go`,
+				templateDir: `/tmp/not/exising/path`,
+			},
+			wantErr:     true,
+			wantNoTests: true,
+		},
+		{
+			name: "Test non bad template formatting",
+			args: args{
+				srcPath:     `testdata/calculator.go`,
+				templateDir: `testdata/bad_customtemplates`,
+			},
+			wantErr:     true,
+			wantNoTests: true,
+		},
+		{
+			name: "Test custom template path",
+			args: args{
+				srcPath:     `testdata/test004.go`,
+				templateDir: `testdata/customtemplates`,
+			},
+			want: mustReadFile(t, "testdata/goldens/function_with_return_value_custom_template.go"),
+		},
 	}
 	tmp, err := ioutil.TempDir("", "gotests_test")
 	if err != nil {
@@ -555,6 +582,7 @@ func TestGenerateTests(t *testing.T) {
 			PrintInputs: tt.args.printInputs,
 			Subtests:    tt.args.subtests,
 			Importer:    func() types.Importer { return tt.args.importer },
+			TemplateDir: tt.args.templateDir,
 		})
 		if (err != nil) != tt.wantErr {
 			t.Errorf("%q. GenerateTests(%v) error = %v, wantErr %v", tt.name, tt.args.srcPath, err, tt.wantErr)

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -17,9 +17,17 @@ import (
 type Options struct {
 	PrintInputs bool
 	Subtests    bool
+	TemplateDir string
 }
 
 func Process(head *models.Header, funcs []*models.Function, opt *Options) ([]byte, error) {
+	if opt != nil && opt.TemplateDir != "" {
+		err := render.LoadCustomTemplates(opt.TemplateDir)
+		if err != nil {
+			return nil, fmt.Errorf("loading custom templates: %v", err)
+		}
+	}
+
 	tf, err := ioutil.TempFile("", "gotests_")
 	if err != nil {
 		return nil, fmt.Errorf("ioutil.TempFile: %v", err)

--- a/testdata/bad_customtemplates/call.tmpl
+++ b/testdata/bad_customtemplates/call.tmpl
@@ -1,0 +1,1 @@
+{{define "call"}}{{with .Receiver}}{{if not .IsStruct}}tt.{{end}}{{Receiver .}}.{{end}}{{.Name}}({{range $i, $el := .Parameters}}{{if $i}}, {{end}}{{if not .IsWriter}}tt.args.{{end}}{{Param .}}{{if .Type.IsVariadic}}...{{end}}{{end}}){{end}}

--- a/testdata/bad_customtemplates/function.tmpl
+++ b/testdata/bad_customtemplates/function.tmpl
@@ -1,0 +1,86 @@
+{{define "function"}}
+{{- $f := .}}
+
+func {{.TestName}}(t *testing.T) {
+	{{- with .Receiver}}
+		{{- if .IsStruct}}
+			{{- if .Fields}}
+				type fields struct {
+				{{- range .Fields}}
+					{{Field .}} {{.Type}}
+				{{- end}}
+				}
+			{{- end}}
+		{{- end}}
+	{{- end}}
+	{{- if .TestParameters}}
+	type args struct {
+		{{- range .TestParameters}}
+				{{Param .}} {{.Type}}
+		{{- end}}
+	}
+	{{- end}}
+	testCases := []struct {
+		name string
+		{{- with .Receiver}}
+			{{- if and .IsStruct .Fields}}
+				fields fields
+			{{- else}}
+				{{Receiver .}} {{.Type}}
+			{{- end}}
+		{{- end}}
+		{{- if .TestParameters}}
+			args args
+		{{- end}}
+		{{- range .TestResults}}
+			{{Want .}} {{.Type}}
+		{{- end}}
+		{{- if .ReturnsError}}
+			wantErr bool
+		{{- end}}
+	}{
+		// TODO: Add test cases.
+	}
+	for {{if not .IsNaked}} _, tt := {{end}} range testCases {
+        {{- if .Subtests }}t.Run(tt.name, func(t *testing.T) { {{- end -}}
+			{{- with .Receiver}}
+				{{- if .IsStruct}}
+					{{Receiver .}} := {{if .Type.IsStar}}&{{end}}{{.Type.Value}}{
+					{{- range .Fields}}
+						{{.Name}}: tt.fields.{{Field .}},
+					{{- end}}
+					}
+				{{- end}}
+			{{- end}}
+			{{- range .Parameters}}
+				{{- if .IsWriter}}
+					{{Param .}} := &bytes.Buffer{}
+				{{- end}}
+			{{- end}}
+			{{- if and (not .OnlyReturnsError) (not .OnlyReturnsOneValue) }}
+				{{template "results" $f}} {{template "call" $f}}
+			{{- end}}
+			{{- if .ReturnsError}}
+				if {{if .OnlyReturnsError}} err := {{template "call" $f}}; {{end}} (err != nil) != tt.wantErr {
+					t.Errorf("{{template "message" $f}} error = %v, wantErr %v", {{template "inputs" $f}} err, tt.wantErr)
+					{{- if .TestResults}}
+						{{if .Subtests }}return{{else}}continue{{end}}
+					{{- end}}
+				}
+			{{- end}}
+			{{- range .TestResults}}
+				{{- if .IsWriter}}
+					if {{Got .}} := {{Param .}}.String(); {{Got .}} != tt.{{Want .}} {
+				{{- else if .IsBasicType}}
+					if {{if $f.OnlyReturnsOneValue}}{{Got .}} := {{template "inline" $f}}; {{end}} {{Got .}} != tt.{{Want .}} {
+				{{- else}}
+					if {{if $f.OnlyReturnsOneValue}}{{Got .}} := {{template "inline" $f}}; {{end}} !reflect.DeepEqual({{Got .}}, tt.{{Want .}}) {
+				{{- end}}
+				t.Errorf("{{template "message" $f}} {{if $f.ReturnsMultiple}}{{Got .}} {{end}}= %v, want %v", {{template "inputs" $f}} {{Got .}}, tt.{{Want .}})
+				}
+			{{- end}}
+		{{- if .Subtests }} }) {{- end -}}
+	}
+}
+
+{{end}}

--- a/testdata/bad_customtemplates/inline.tmpl
+++ b/testdata/bad_customtemplates/inline.tmpl
@@ -1,0 +1,1 @@
+{{define "inline"}} {{template "call" .}} {{end}}

--- a/testdata/bad_customtemplates/inputs.tmpl
+++ b/testdata/bad_customtemplates/inputs.tmpl
@@ -1,0 +1,1 @@
+{{define "inputs"}}{{$f := .}}{{if not .Subtests}}tt.name, {{end}}{{if $f.PrintInputs}}{{range $f.Parameters}}tt.args.{{Param .}}, {{end}}{{end}}{{end}}

--- a/testdata/bad_customtemplates/message.tmpl
+++ b/testdata/bad_customtemplates/message.tmpl
@@ -1,0 +1,3 @@
+{{define "message" -}}
+{{if not .Subtests}}%q. {{end}}{{with .Receiver}}{{.Type.Value}}.{{end}}{{.Name}}({{if .PrintInputs}}{{range $i, $el := .Parameters}}{{if $i}}, {{end}}%v{{end}}{{end}})
+{{- end}}

--- a/testdata/bad_customtemplates/results.tmpl
+++ b/testdata/bad_customtemplates/results.tmpl
@@ -1,0 +1,1 @@
+{{define "results"}} {{range $i, $el := .Results}}{{if $i}}, {{end}}{{Got .}}{{end}}{{if .ReturnsError}}, err{{end}} {{if or .Results .ReturnsError}} := {{end}} {{end}} {{end}}

--- a/testdata/customtemplates/call.tmpl
+++ b/testdata/customtemplates/call.tmpl
@@ -1,0 +1,1 @@
+{{define "call"}}{{with .Receiver}}{{if not .IsStruct}}tt.{{end}}{{Receiver .}}.{{end}}{{.Name}}({{range $i, $el := .Parameters}}{{if $i}}, {{end}}{{if not .IsWriter}}tt.args.{{end}}{{Param .}}{{if .Type.IsVariadic}}...{{end}}{{end}}){{end}}

--- a/testdata/customtemplates/function.tmpl
+++ b/testdata/customtemplates/function.tmpl
@@ -1,0 +1,86 @@
+{{define "function"}}
+{{- $f := .}}
+
+func {{.TestName}}(t *testing.T) {
+	{{- with .Receiver}}
+		{{- if .IsStruct}}
+			{{- if .Fields}}
+				type fields struct {
+				{{- range .Fields}}
+					{{Field .}} {{.Type}}
+				{{- end}}
+				}
+			{{- end}}
+		{{- end}}
+	{{- end}}
+	{{- if .TestParameters}}
+	type args struct {
+		{{- range .TestParameters}}
+				{{Param .}} {{.Type}}
+		{{- end}}
+	}
+	{{- end}}
+	testCases := []struct {
+		name string
+		{{- with .Receiver}}
+			{{- if and .IsStruct .Fields}}
+				fields fields
+			{{- else}}
+				{{Receiver .}} {{.Type}}
+			{{- end}}
+		{{- end}}
+		{{- if .TestParameters}}
+			args args
+		{{- end}}
+		{{- range .TestResults}}
+			{{Want .}} {{.Type}}
+		{{- end}}
+		{{- if .ReturnsError}}
+			wantErr bool
+		{{- end}}
+	}{
+		// TODO: Add test cases.
+	}
+	for {{if not .IsNaked}} _, tt := {{end}} range testCases {
+        {{- if .Subtests }}t.Run(tt.name, func(t *testing.T) { {{- end -}}
+			{{- with .Receiver}}
+				{{- if .IsStruct}}
+					{{Receiver .}} := {{if .Type.IsStar}}&{{end}}{{.Type.Value}}{
+					{{- range .Fields}}
+						{{.Name}}: tt.fields.{{Field .}},
+					{{- end}}
+					}
+				{{- end}}
+			{{- end}}
+			{{- range .Parameters}}
+				{{- if .IsWriter}}
+					{{Param .}} := &bytes.Buffer{}
+				{{- end}}
+			{{- end}}
+			{{- if and (not .OnlyReturnsError) (not .OnlyReturnsOneValue) }}
+				{{template "results" $f}} {{template "call" $f}}
+			{{- end}}
+			{{- if .ReturnsError}}
+				if {{if .OnlyReturnsError}} err := {{template "call" $f}}; {{end}} (err != nil) != tt.wantErr {
+					t.Errorf("{{template "message" $f}} error = %v, wantErr %v", {{template "inputs" $f}} err, tt.wantErr)
+					{{- if .TestResults}}
+						{{if .Subtests }}return{{else}}continue{{end}}
+					{{- end}}
+				}
+			{{- end}}
+			{{- range .TestResults}}
+				{{- if .IsWriter}}
+					if {{Got .}} := {{Param .}}.String(); {{Got .}} != tt.{{Want .}} {
+				{{- else if .IsBasicType}}
+					if {{if $f.OnlyReturnsOneValue}}{{Got .}} := {{template "inline" $f}}; {{end}} {{Got .}} != tt.{{Want .}} {
+				{{- else}}
+					if {{if $f.OnlyReturnsOneValue}}{{Got .}} := {{template "inline" $f}}; {{end}} !reflect.DeepEqual({{Got .}}, tt.{{Want .}}) {
+				{{- end}}
+				t.Errorf("{{template "message" $f}} {{if $f.ReturnsMultiple}}{{Got .}} {{end}}= %v, want %v", {{template "inputs" $f}} {{Got .}}, tt.{{Want .}})
+				}
+			{{- end}}
+		{{- if .Subtests }} }) {{- end -}}
+	}
+}
+
+{{end}}

--- a/testdata/customtemplates/header.tmpl
+++ b/testdata/customtemplates/header.tmpl
@@ -1,0 +1,10 @@
+{{define "header"}}
+{{range .Comments}}{{.}}
+{{end}}
+package {{.Package}}
+
+import (
+{{range .Imports}}{{.Name}} {{.Path}}
+{{end}}
+)
+{{end}}

--- a/testdata/customtemplates/inline.tmpl
+++ b/testdata/customtemplates/inline.tmpl
@@ -1,0 +1,1 @@
+{{define "inline"}} {{template "call" .}} {{end}}

--- a/testdata/customtemplates/inputs.tmpl
+++ b/testdata/customtemplates/inputs.tmpl
@@ -1,0 +1,1 @@
+{{define "inputs"}}{{$f := .}}{{if not .Subtests}}tt.name, {{end}}{{if $f.PrintInputs}}{{range $f.Parameters}}tt.args.{{Param .}}, {{end}}{{end}}{{end}}

--- a/testdata/customtemplates/message.tmpl
+++ b/testdata/customtemplates/message.tmpl
@@ -1,0 +1,3 @@
+{{define "message" -}}
+{{if not .Subtests}}%q. {{end}}{{with .Receiver}}{{.Type.Value}}.{{end}}{{.Name}}({{if .PrintInputs}}{{range $i, $el := .Parameters}}{{if $i}}, {{end}}%v{{end}}{{end}})
+{{- end}}

--- a/testdata/customtemplates/results.tmpl
+++ b/testdata/customtemplates/results.tmpl
@@ -1,0 +1,1 @@
+{{define "results"}} {{range $i, $el := .Results}}{{if $i}}, {{end}}{{Got .}}{{end}}{{if .ReturnsError}}, err{{end}} {{if or .Results .ReturnsError}} := {{end}} {{end}}

--- a/testdata/goldens/function_with_return_value_custom_template.go
+++ b/testdata/goldens/function_with_return_value_custom_template.go
@@ -1,0 +1,17 @@
+package testdata
+
+import "testing"
+
+func TestFoo4(t *testing.T) {
+	testCases := []struct {
+		name string
+		want bool
+	}{
+	// TODO: Add test cases.
+	}
+	for _, tt := range testCases {
+		if got := Foo4(); got != tt.want {
+			t.Errorf("%q. Foo4() = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
I have added the ability to use custom templates for generating tests. The templates should just be a modified copy of the ones provided in the library. 
This is useful for us as we would only like to make a few minor modifications for our specific use. There was also demand for it in issues like #5  

`-template` accepts a path to a template folder that is used to generate the test. Allowing people to use their own templates when generating tests

Any tips and feedback welcome! 