### PR TITLE
failing tests with Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
   - 1.7.x
   - 1.8.x
   - 1.9.x
+  - 1.10.x
 before_install:
   - go get github.com/mattn/goveralls
   - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi

--- a/gotests_test.go
+++ b/gotests_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"path"
 	"regexp"
+	"strings"
 	"testing"
 	"unicode"
 )
@@ -571,7 +572,7 @@ func TestGenerateTests(t *testing.T) {
 		if tt.wantNoTests || tt.wantMultipleTests {
 			continue
 		}
-		if got := string(gts[0].Output); got != tt.want {
+		if got := string(gts[0].Output); ignoreTabs(got) != ignoreTabs(tt.want) {
 			t.Errorf("%q. GenerateTests(%v) = \n%v, want \n%v", tt.name, tt.args.srcPath, got, tt.want)
 			outputResult(t, tmp, tt.name, gts[0].Output)
 		}
@@ -607,6 +608,10 @@ func toSnakeCase(s string) string {
 		res = append(res, r)
 	}
 	return string(res)
+}
+
+func ignoreTabs(s string) string {
+	return strings.Replace(s, "\t", "", -1)
 }
 
 // 249032394 ns/op


### PR DESCRIPTION
As the linked travis build demonstrates, the test `TestGenerateTests` fails with Go 1.10 due to changes to `go fmt`.

Here's a breakdown of the issue:

* gotests generates a test
* the generated test is then formatted (using Go 1.10 fmt)
* the formatted generated output is compared against the golden files  which were formatted using an older version of Go
* They don't match.

The exact formatting problem lies in this block:

![screen shot 2018-03-19 at 18 24 21](https://user-images.githubusercontent.com/96384/37611558-f1d0f652-2ba2-11e8-8406-92b1d511b1b7.png)

I'm still thinking about how to go about this in a clean way.