### PR TITLE
Format the golden files using the imports pkg to avoid formatting related test failures

### DIFF
--- a/gotests_test.go
+++ b/gotests_test.go
@@ -6,11 +6,10 @@ import (
 	"io/ioutil"
 	"path"
 	"regexp"
-	"strings"
 	"testing"
 	"unicode"
 
-	"github.com/cweill/gotests/internal/output"
+	"golang.org/x/tools/imports"
 )
 
 func TestGenerateTests(t *testing.T) {
@@ -76,7 +75,7 @@ func TestGenerateTests(t *testing.T) {
 			},
 			wantNoTests: false,
 			wantErr:     false,
-			want:        mustReadFile(t, `testdata/goldens/target_test_file.go`),
+			want:        mustReadAndFormatGoFile(t, `testdata/goldens/target_test_file.go`),
 		}, {
 			name: "Target test file without only flag",
 			args: args{
@@ -85,7 +84,7 @@ func TestGenerateTests(t *testing.T) {
 			},
 			wantNoTests: false,
 			wantErr:     false,
-			want:        mustReadFile(t, `testdata/goldens/target_test_file.go`),
+			want:        mustReadAndFormatGoFile(t, `testdata/goldens/target_test_file.go`),
 		}, {
 			name: "No funcs",
 			args: args{
@@ -97,250 +96,250 @@ func TestGenerateTests(t *testing.T) {
 			args: args{
 				srcPath: `testdata/test001.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_with_neither_receiver_parameters_nor_results.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_with_neither_receiver_parameters_nor_results.go"),
 		}, {
 			name: "Function with anonymous arguments",
 			args: args{
 				srcPath: `testdata/test002.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_with_anonymous_arguments.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_with_anonymous_arguments.go"),
 		}, {
 			name: "Function with named argument",
 			args: args{
 				srcPath: `testdata/test003.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_with_named_argument.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_with_named_argument.go"),
 		}, {
 			name: "Function with return value",
 			args: args{
 				srcPath: `testdata/test004.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_with_return_value.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_with_return_value.go"),
 		}, {
 			name: "Function returning an error",
 			args: args{
 				srcPath: `testdata/test005.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_returning_an_error.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_returning_an_error.go"),
 		}, {
 			name: "Function with multiple arguments",
 			args: args{
 				srcPath: `testdata/test006.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_with_multiple_arguments.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_with_multiple_arguments.go"),
 		}, {
 			name: "Print inputs with multiple arguments",
 			args: args{
 				srcPath:     `testdata/test006.go`,
 				printInputs: true,
 			},
-			want: mustReadFile(t, "testdata/goldens/print_inputs_with_multiple_arguments.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/print_inputs_with_multiple_arguments.go"),
 		}, {
 			name: "Method on a struct pointer",
 			args: args{
 				srcPath: `testdata/test007.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/method_on_a_struct_pointer.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/method_on_a_struct_pointer.go"),
 		}, {
 			name: "Print inputs with single argument",
 			args: args{
 				srcPath:     `testdata/test007.go`,
 				printInputs: true,
 			},
-			want: mustReadFile(t, "testdata/goldens/print_inputs_with_single_argument.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/print_inputs_with_single_argument.go"),
 		}, {
 			name: "Function with struct pointer argument and return type",
 			args: args{
 				srcPath: `testdata/test008.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_with_struct_pointer_argument_and_return_type.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_with_struct_pointer_argument_and_return_type.go"),
 		}, {
 			name: "Struct value method with struct value return type",
 			args: args{
 				srcPath: `testdata/test009.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/struct_value_method_with_struct_value_return_type.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/struct_value_method_with_struct_value_return_type.go"),
 		}, {
 			name: "Function with map argument and return type",
 			args: args{
 				srcPath: `testdata/test010.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_with_map_argument_and_return_type.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_with_map_argument_and_return_type.go"),
 		}, {
 			name: "Function with slice argument and return type",
 			args: args{
 				srcPath: `testdata/test011.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_with_slice_argument_and_return_type.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_with_slice_argument_and_return_type.go"),
 		}, {
 			name: "Function returning only an error",
 			args: args{
 				srcPath: `testdata/test012.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_returning_only_an_error.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_returning_only_an_error.go"),
 		}, {
 			name: "Function with a function parameter",
 			args: args{
 				srcPath: `testdata/test013.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_with_a_function_parameter.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_with_a_function_parameter.go"),
 		}, {
 			name: "Function with a function parameter with its own parameters and result",
 			args: args{
 				srcPath: `testdata/test014.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_with_a_function_parameter_with_its_own_parameters_and_result.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_with_a_function_parameter_with_its_own_parameters_and_result.go"),
 		}, {
 			name: "Function with a function parameter that returns two results",
 			args: args{
 				srcPath: `testdata/test015.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_with_a_function_parameter_that_returns_two_results.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_with_a_function_parameter_that_returns_two_results.go"),
 		}, {
 			name: "Function with defined interface type parameter and result",
 			args: args{
 				srcPath: `testdata/test016.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_with_defined_interface_type_parameter_and_result.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_with_defined_interface_type_parameter_and_result.go"),
 		}, {
 			name: "Function with imported interface receiver, parameter, and result",
 			args: args{
 				srcPath: `testdata/test017.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_with_imported_interface_receiver_parameter_and_result.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_with_imported_interface_receiver_parameter_and_result.go"),
 		}, {
 			name: "Function with imported struct receiver, parameter, and result",
 			args: args{
 				srcPath: `testdata/test018.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_with_imported_struct_receiver_parameter_and_result.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_with_imported_struct_receiver_parameter_and_result.go"),
 		}, {
 			name: "Function with multiple parameters of the same type",
 			args: args{
 				srcPath: `testdata/test019.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_with_multiple_parameters_of_the_same_type.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_with_multiple_parameters_of_the_same_type.go"),
 		}, {
 			name: "Function with a variadic parameter",
 			args: args{
 				srcPath: `testdata/test020.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_with_a_variadic_parameter.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_with_a_variadic_parameter.go"),
 		}, {
 			name: "Function with interface{} parameter and result",
 			args: args{
 				srcPath: `testdata/test021.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_with_interface_parameter_and_result.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_with_interface_parameter_and_result.go"),
 		}, {
 			name: "Function with named imports",
 			args: args{
 				srcPath: `testdata/test022.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_with_named_imports.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_with_named_imports.go"),
 		}, {
 			name: "Function with channel parameter and result",
 			args: args{
 				srcPath: `testdata/test023.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_with_channel_parameter_and_result.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_with_channel_parameter_and_result.go"),
 		}, {
 			name: "File with multiple imports",
 			args: args{
 				srcPath: `testdata/test024.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/file_with_multiple_imports.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/file_with_multiple_imports.go"),
 		}, {
 			name: "Function returning two results and an error",
 			args: args{
 				srcPath: `testdata/test025.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_returning_two_results_and_an_error.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_returning_two_results_and_an_error.go"),
 		}, {
 			name: "Multiple named results",
 			args: args{
 				srcPath: `testdata/test026.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/multiple_named_results.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/multiple_named_results.go"),
 		}, {
 			name: "Two different structs with same method name",
 			args: args{
 				srcPath: `testdata/test027.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/two_different_structs_with_same_method_name.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/two_different_structs_with_same_method_name.go"),
 		}, {
 			name: "Underlying types",
 			args: args{
 				srcPath: `testdata/test028.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/underlying_types.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/underlying_types.go"),
 		}, {
 			name: "Struct receiver with multiple fields",
 			args: args{
 				srcPath: `testdata/test029.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/struct_receiver_with_multiple_fields.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/struct_receiver_with_multiple_fields.go"),
 		}, {
 			name: "Struct receiver with anonymous fields",
 			args: args{
 				srcPath: `testdata/test030.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/struct_receiver_with_anonymous_fields.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/struct_receiver_with_anonymous_fields.go"),
 		}, {
 			name: "io.Writer parameters",
 			args: args{
 				srcPath: `testdata/test031.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/io_writer_parameters.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/io_writer_parameters.go"),
 		}, {
 			name: "Two structs with same method name",
 			args: args{
 				srcPath: `testdata/test032.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/two_structs_with_same_method_name.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/two_structs_with_same_method_name.go"),
 		}, {
 			name: "Functions and methods with 'name' receivers, parameters, and results",
 			args: args{
 				srcPath: `testdata/test033.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/functions_and_methods_with_name_receivers_parameters_and_results.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/functions_and_methods_with_name_receivers_parameters_and_results.go"),
 		}, {
 			name: "Receiver struct with reserved field names",
 			args: args{
 				srcPath: `testdata/test034.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/receiver_struct_with_reserved_field_names.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/receiver_struct_with_reserved_field_names.go"),
 		}, {
 			name: "Receiver struct with fields with complex package names",
 			args: args{
 				srcPath: `testdata/test035.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/receiver_struct_with_fields_with_complex_package_names.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/receiver_struct_with_fields_with_complex_package_names.go"),
 		}, {
 			name: "Functions and receivers with same names except exporting",
 			args: args{
 				srcPath: `testdata/test036.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/functions_and_receivers_with_same_names_except_exporting.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/functions_and_receivers_with_same_names_except_exporting.go"),
 		}, {
 			name: "Receiver is indirect imported struct",
 			args: args{
 				srcPath: `testdata/test037.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/receiver_is_indirect_imported_struct.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/receiver_is_indirect_imported_struct.go"),
 		}, {
 			name: "Multiple functions",
 			args: args{
 				srcPath: `testdata/test_filter.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/multiple_functions.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/multiple_functions.go"),
 		}, {
 			name: "Multiple functions with only",
 			args: args{
 				srcPath: `testdata/test_filter.go`,
 				only:    regexp.MustCompile("FooFilter|bazFilter"),
 			},
-			want: mustReadFile(t, "testdata/goldens/multiple_functions_with_only.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/multiple_functions_with_only.go"),
 		}, {
 			name: "Multiple functions with only regexp without matches",
 			args: args{
@@ -354,28 +353,28 @@ func TestGenerateTests(t *testing.T) {
 				srcPath: `testdata/test_filter.go`,
 				only:    regexp.MustCompile("(?i)fooFilter|BazFilter"),
 			},
-			want: mustReadFile(t, "testdata/goldens/multiple_functions_with_case-insensitive_only.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/multiple_functions_with_case-insensitive_only.go"),
 		}, {
 			name: "Multiple functions with only filtering on receiver",
 			args: args{
 				srcPath: `testdata/test_filter.go`,
 				only:    regexp.MustCompile("^BarBarFilter$"),
 			},
-			want: mustReadFile(t, "testdata/goldens/multiple_functions_with_only_filtering_on_receiver.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/multiple_functions_with_only_filtering_on_receiver.go"),
 		}, {
 			name: "Multiple functions with only filtering on method",
 			args: args{
 				srcPath: `testdata/test_filter.go`,
 				only:    regexp.MustCompile("^(BarFilter)$"),
 			},
-			want: mustReadFile(t, "testdata/goldens/multiple_functions_with_only_filtering_on_method.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/multiple_functions_with_only_filtering_on_method.go"),
 		}, {
 			name: "Multiple functions filtering exported",
 			args: args{
 				srcPath:  `testdata/test_filter.go`,
 				exported: true,
 			},
-			want: mustReadFile(t, "testdata/goldens/multiple_functions_filtering_exported.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/multiple_functions_filtering_exported.go"),
 		}, {
 			name: "Multiple functions filtering exported with only",
 			args: args{
@@ -383,7 +382,7 @@ func TestGenerateTests(t *testing.T) {
 				only:     regexp.MustCompile(`FooFilter`),
 				exported: true,
 			},
-			want: mustReadFile(t, "testdata/goldens/multiple_functions_filtering_exported_with_only.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/multiple_functions_filtering_exported_with_only.go"),
 		}, {
 			name: "Multiple functions filtering all out",
 			args: args{
@@ -397,14 +396,14 @@ func TestGenerateTests(t *testing.T) {
 				srcPath: `testdata/test_filter.go`,
 				excl:    regexp.MustCompile("FooFilter|bazFilter"),
 			},
-			want: mustReadFile(t, "testdata/goldens/multiple_functions_with_excl.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/multiple_functions_with_excl.go"),
 		}, {
 			name: "Multiple functions with case-insensitive excl",
 			args: args{
 				srcPath: `testdata/test_filter.go`,
 				excl:    regexp.MustCompile("(?i)foOFilter|BaZFilter"),
 			},
-			want: mustReadFile(t, "testdata/goldens/multiple_functions_with_case-insensitive_excl.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/multiple_functions_with_case-insensitive_excl.go"),
 		}, {
 			name: "Multiple functions filtering exported with excl",
 			args: args{
@@ -412,7 +411,7 @@ func TestGenerateTests(t *testing.T) {
 				excl:     regexp.MustCompile(`FooFilter`),
 				exported: true,
 			},
-			want: mustReadFile(t, "testdata/goldens/multiple_functions_filtering_exported_with_excl.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/multiple_functions_filtering_exported_with_excl.go"),
 		}, {
 			name: "Multiple functions excluding all",
 			args: args{
@@ -426,14 +425,14 @@ func TestGenerateTests(t *testing.T) {
 				srcPath: `testdata/test_filter.go`,
 				excl:    regexp.MustCompile("^BarBarFilter$"),
 			},
-			want: mustReadFile(t, "testdata/goldens/multiple_functions_excluding_on_receiver.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/multiple_functions_excluding_on_receiver.go"),
 		}, {
 			name: "Multiple functions excluding on method",
 			args: args{
 				srcPath: `testdata/test_filter.go`,
 				excl:    regexp.MustCompile("^BarFilter$"),
 			},
-			want: mustReadFile(t, "testdata/goldens/multiple_functions_excluding_on_method.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/multiple_functions_excluding_on_method.go"),
 		}, {
 			name: "Multiple functions with both only and excl",
 			args: args{
@@ -441,7 +440,7 @@ func TestGenerateTests(t *testing.T) {
 				only:    regexp.MustCompile("BarFilter"),
 				excl:    regexp.MustCompile("FooFilter"),
 			},
-			want: mustReadFile(t, "testdata/goldens/multiple_functions_with_both_only_and_excl.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/multiple_functions_with_both_only_and_excl.go"),
 		}, {
 			name: "Multiple functions with only and excl competing",
 			args: args{
@@ -449,38 +448,38 @@ func TestGenerateTests(t *testing.T) {
 				only:    regexp.MustCompile("FooFilter|BarFilter"),
 				excl:    regexp.MustCompile("FooFilter|bazFilter"),
 			},
-			want: mustReadFile(t, "testdata/goldens/multiple_functions_with_only_and_excl_competing.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/multiple_functions_with_only_and_excl_competing.go"),
 		}, {
 			name: "Custom importer fails",
 			args: args{
 				srcPath:  `testdata/test_filter.go`,
 				importer: &fakeImporter{err: errors.New("error")},
 			},
-			want: mustReadFile(t, "testdata/goldens/custom_importer_fails.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/custom_importer_fails.go"),
 		}, {
 			name: "Existing test file",
 			args: args{
 				srcPath: `testdata/test100.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/existing_test_file.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/existing_test_file.go"),
 		}, {
 			name: "Existing test file with just package declaration",
 			args: args{
 				srcPath: `testdata/test101.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/existing_test_file_with_just_package_declaration.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/existing_test_file_with_just_package_declaration.go"),
 		}, {
 			name: "Existing test file with no functions",
 			args: args{
 				srcPath: `testdata/test102.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/existing_test_file_with_no_functions.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/existing_test_file_with_no_functions.go"),
 		}, {
 			name: "Existing test file with multiple imports",
 			args: args{
 				srcPath: `testdata/test200.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/existing_test_file_with_multiple_imports.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/existing_test_file_with_multiple_imports.go"),
 		}, {
 			name: "Entire testdata directory",
 			args: args{
@@ -492,59 +491,59 @@ func TestGenerateTests(t *testing.T) {
 			args: args{
 				srcPath: `testdata/mixedpkg/bar.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/different_packages_in_same_directory_-_part_1.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/different_packages_in_same_directory_-_part_1.go"),
 		}, {
 			name: "Different packages in same directory - part 2",
 			args: args{
 				srcPath: `testdata/mixedpkg/foo.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/different_packages_in_same_directory_-_part_2.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/different_packages_in_same_directory_-_part_2.go"),
 		}, {
 			name: "Empty test file",
 			args: args{
 				srcPath: `testdata/blanktest/blank.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/empty_test_file.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/empty_test_file.go"),
 		}, {
 			name: "Test file with syntax errors",
 			args: args{
 				srcPath: `testdata/syntaxtest/syntax.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/test_file_with_syntax_errors.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/test_file_with_syntax_errors.go"),
 		}, {
 			name: "Undefined types",
 			args: args{
 				srcPath: `testdata/undefinedtypes/undefined.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/undefined_types.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/undefined_types.go"),
 		}, {
 			name: "Subtest Edition - Functions and receivers with same names except exporting",
 			args: args{
 				srcPath:  `testdata/test036.go`,
 				subtests: true,
 			},
-			want: mustReadFile(t, "testdata/goldens/subtest_edition_-_functions_and_receivers_with_same_names_except_exporting.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/subtest_edition_-_functions_and_receivers_with_same_names_except_exporting.go"),
 		},
 		{
 			name: "Init function",
 			args: args{
 				srcPath: `testdata/init_func.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/no_init_funcs.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/no_init_funcs.go"),
 		},
 		{
 			name: "Existing test file with package level comments",
 			args: args{
 				srcPath: `testdata/test_existing_test_file_with_comments.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/existing_test_file_with_package_level_comments.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/existing_test_file_with_package_level_comments.go"),
 		},
 		{
 			name: "Existing test file with package level comments with newline",
 			args: args{
 				srcPath: `testdata/test_existing_test_file_with_comments.go`,
 			},
-			want: mustReadFile(t, "testdata/goldens/existing_test_file_with_package_level_comments.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/existing_test_file_with_package_level_comments.go"),
 		},
 		{
 			name: "Test non existing template path",
@@ -570,7 +569,7 @@ func TestGenerateTests(t *testing.T) {
 				srcPath:     `testdata/test004.go`,
 				templateDir: `testdata/customtemplates`,
 			},
-			want: mustReadFile(t, "testdata/goldens/function_with_return_value_custom_template.go"),
+			want: mustReadAndFormatGoFile(t, "testdata/goldens/function_with_return_value_custom_template.go"),
 		},
 	}
 	tmp, err := ioutil.TempDir("", "gotests_test")
@@ -609,19 +608,12 @@ func TestGenerateTests(t *testing.T) {
 	}
 }
 
-func mustReadFile(t *testing.T, filename string) string {
-	b, err := ioutil.ReadFile(filename)
+func mustReadAndFormatGoFile(t *testing.T, filename string) string {
+	fmted, err := imports.Process(filename, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	// The newly generated test are formatted using the imports pkg.
-	// We need do the same to the golden files, otherwise we might end up with formatting mismatch
-	res, err := output.ProcessImports(filename, b)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return string(res)
+	return string(fmted)
 }
 
 func outputResult(t *testing.T, tmpDir, testName string, got []byte) {
@@ -645,10 +637,6 @@ func toSnakeCase(s string) string {
 		res = append(res, r)
 	}
 	return string(res)
-}
-
-func gofmt(s string) string {
-	return strings.Replace(s, "\t", "", -1)
 }
 
 // 249032394 ns/op

--- a/gotests_test.go
+++ b/gotests_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"unicode"
+
+	"github.com/cweill/gotests/internal/output"
 )
 
 func TestGenerateTests(t *testing.T) {
@@ -600,7 +602,7 @@ func TestGenerateTests(t *testing.T) {
 		if tt.wantNoTests || tt.wantMultipleTests {
 			continue
 		}
-		if got := string(gts[0].Output); ignoreTabs(got) != ignoreTabs(tt.want) {
+		if got := string(gts[0].Output); got != tt.want {
 			t.Errorf("%q. GenerateTests(%v) = \n%v, want \n%v", tt.name, tt.args.srcPath, got, tt.want)
 			outputResult(t, tmp, tt.name, gts[0].Output)
 		}
@@ -612,7 +614,14 @@ func mustReadFile(t *testing.T, filename string) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return string(b)
+
+	// The newly generated test are formatted using the imports pkg.
+	// We need do the same to the golden files, otherwise we might end up with formatting mismatch
+	res, err := output.ProcessImports(filename, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(res)
 }
 
 func outputResult(t *testing.T, tmpDir, testName string, got []byte) {
@@ -638,7 +647,7 @@ func toSnakeCase(s string) string {
 	return string(res)
 }
 
-func ignoreTabs(s string) string {
+func gofmt(s string) string {
 	return strings.Replace(s, "\t", "", -1)
 }
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -38,7 +38,12 @@ func Process(head *models.Header, funcs []*models.Function, opt *Options) ([]byt
 	if err := writeTests(b, head, funcs, opt); err != nil {
 		return nil, err
 	}
-	out, err := imports.Process(tf.Name(), b.Bytes(), nil)
+
+	return ProcessImports(tf.Name(), b.Bytes())
+}
+
+func ProcessImports(filename string, src []byte) ([]byte, error) {
+	out, err := imports.Process(filename, src, nil)
 	if err != nil {
 		return nil, fmt.Errorf("imports.Process: %v", err)
 	}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -39,11 +39,7 @@ func Process(head *models.Header, funcs []*models.Function, opt *Options) ([]byt
 		return nil, err
 	}
 
-	return ProcessImports(tf.Name(), b.Bytes())
-}
-
-func ProcessImports(filename string, src []byte) ([]byte, error) {
-	out, err := imports.Process(filename, src, nil)
+	out, err := imports.Process(tf.Name(), b.Bytes(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("imports.Process: %v", err)
 	}


### PR DESCRIPTION
The golden files are formatted using a specific version of Go and
commited.
The generated tests are always formnatted using the current Go version.

The are then comapred against each other.

This broke with Go 1.10 due to changes to the formatting rules.

A previous PR fixed this using a *brittle approach*: strip tabs from the
both the goldens and the generated tests before comapring. See #62

@shurcooL propsed a much more elgant solution: after reading the
goldens, format them using the current Go version before comparing.

This PR does just that.