### PR TITLE
Use -exported instead of wrong -export name for flag usage

### DIFF
--- a/gotests/process/process.go
+++ b/gotests/process/process.go
@@ -15,6 +15,11 @@ import (
 
 const newFilePerm os.FileMode = 0644
 
+const (
+	specifyFlagMessage = "Please specify either the -only, -excl, -exported, or -all flag"
+	specifyFileMessage = "Please specify a file or directory containing the source"
+)
+
 // Set of options to use when generating tests.
 type Options struct {
 	OnlyFuncs     string // Regexp string for filter matches.
@@ -39,7 +44,7 @@ func Run(out io.Writer, args []string, opts *Options) {
 		return
 	}
 	if len(args) == 0 {
-		fmt.Fprintln(out, "Please specify a file or directory containing the source")
+		fmt.Fprintln(out, specifyFileMessage)
 		return
 	}
 	for _, path := range args {
@@ -49,7 +54,7 @@ func Run(out io.Writer, args []string, opts *Options) {
 
 func parseOptions(out io.Writer, opt *Options) *gotests.Options {
 	if opt.OnlyFuncs == "" && opt.ExclFuncs == "" && !opt.ExportedFuncs && !opt.AllFuncs {
-		fmt.Fprintln(out, "Please specify either the -only, -excl, -export, or -all flag")
+		fmt.Fprintln(out, specifyFlagMessage)
 		return nil
 	}
 	onlyRE, err := parseRegexp(opt.OnlyFuncs)

--- a/gotests/process/process_test.go
+++ b/gotests/process/process_test.go
@@ -17,22 +17,22 @@ func TestRun(t *testing.T) {
 			name: "Nil options and nil args",
 			args: nil,
 			opts: nil,
-			want: "Please specify either the -only, -excl, -export, or -all flag\n",
+			want: specifyFlagMessage + "\n",
 		}, {
 			name: "Nil options",
 			args: []string{"testdata/foobar.go"},
 			opts: nil,
-			want: "Please specify either the -only, -excl, -export, or -all flag\n",
+			want: specifyFlagMessage + "\n",
 		}, {
 			name: "Empty options",
 			args: []string{"testdata/foobar.go"},
 			opts: &Options{},
-			want: "Please specify either the -only, -excl, -export, or -all flag\n",
+			want: specifyFlagMessage + "\n",
 		}, {
 			name: "Non-empty options with no args",
 			args: []string{},
 			opts: &Options{AllFuncs: true},
-			want: "Please specify a file or directory containing the source\n",
+			want: specifyFileMessage + "\n",
 		}, {
 			name: "OnlyFuncs option w/ no matches",
 			args: []string{"testdata/foobar.go"},


### PR DESCRIPTION
problem described in https://github.com/cweill/gotests/issues/70