### PR TITLE
gotests generate test names with MixedCaps

### DIFF
--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -126,7 +126,7 @@ func (f *Function) FullName() string {
 	return strings.Title(r) + strings.Title(f.Name)
 }
 
-func (f *Function) Tes_tName() string {
+func (f *Function) TestName() string {
 	if strings.HasPrefix(f.Name, "Test") {
 		return f.Name
 	}

--- a/testdata/goldens/custom_importer_fails.go
+++ b/testdata/goldens/custom_importer_fails.go
@@ -15,7 +15,7 @@ func TestFooFilter(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := FooFilter(tt.args.strs)
@@ -29,7 +29,7 @@ func TestFooFilter(t *testing.T) {
 	}
 }
 
-func TestBar_BarFilter(t *testing.T) {
+func TestBarBarFilter(t *testing.T) {
 	type args struct {
 		i interface{}
 	}
@@ -39,7 +39,7 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		b := &Bar{}
@@ -49,7 +49,7 @@ func TestBar_BarFilter(t *testing.T) {
 	}
 }
 
-func Test_bazFilter(t *testing.T) {
+func TestBazFilter(t *testing.T) {
 	type args struct {
 		f *float64
 	}
@@ -58,7 +58,7 @@ func Test_bazFilter(t *testing.T) {
 		args args
 		want float64
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := bazFilter(tt.args.f); got != tt.want {

--- a/testdata/goldens/different_packages_in_same_directory_-_part_1.go
+++ b/testdata/goldens/different_packages_in_same_directory_-_part_1.go
@@ -2,7 +2,7 @@ package bar
 
 import "testing"
 
-func TestBar_Bar(t *testing.T) {
+func TestBarBar(t *testing.T) {
 	type fields struct {
 		Foo string
 	}
@@ -15,7 +15,7 @@ func TestBar_Bar(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		b := &Bar{

--- a/testdata/goldens/different_packages_in_same_directory_-_part_2.go
+++ b/testdata/goldens/different_packages_in_same_directory_-_part_2.go
@@ -2,7 +2,7 @@ package foo
 
 import "testing"
 
-func TestFoo_Foo(t *testing.T) {
+func TestFooFoo(t *testing.T) {
 	type fields struct {
 		Bar string
 	}
@@ -15,7 +15,7 @@ func TestFoo_Foo(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		f := &Foo{

--- a/testdata/goldens/existing_test_file.go
+++ b/testdata/goldens/existing_test_file.go
@@ -55,7 +55,7 @@ func TestFoo100(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := Foo100(tt.args.strs)
@@ -65,44 +65,6 @@ func TestFoo100(t *testing.T) {
 		}
 		if !reflect.DeepEqual(got, tt.want) {
 			t.Errorf("%q. Foo100() = %v, want %v", tt.name, got, tt.want)
-		}
-	}
-}
-
-func TestBar_Bar100(t *testing.T) {
-	type args struct {
-		i interface{}
-	}
-	tests := []struct {
-		name    string
-		b       *Bar
-		args    args
-		wantErr bool
-	}{
-	// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		b := &Bar{}
-		if err := b.Bar100(tt.args.i); (err != nil) != tt.wantErr {
-			t.Errorf("%q. Bar.Bar100() error = %v, wantErr %v", tt.name, err, tt.wantErr)
-		}
-	}
-}
-
-func Test_baz100(t *testing.T) {
-	type args struct {
-		f *float64
-	}
-	tests := []struct {
-		name string
-		args args
-		want float64
-	}{
-	// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		if got := baz100(tt.args.f); got != tt.want {
-			t.Errorf("%q. baz100() = %v, want %v", tt.name, got, tt.want)
 		}
 	}
 }

--- a/testdata/goldens/functions_and_methods_with_name_receivers_parameters_and_results.go
+++ b/testdata/goldens/functions_and_methods_with_name_receivers_parameters_and_results.go
@@ -2,7 +2,7 @@ package testdata
 
 import "testing"
 
-func Test_name_Name(t *testing.T) {
+func TestNameName(t *testing.T) {
 	type args struct {
 		n string
 	}
@@ -12,7 +12,7 @@ func Test_name_Name(t *testing.T) {
 		args args
 		want string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := tt.n.Name(tt.args.n); got != tt.want {
@@ -21,7 +21,7 @@ func Test_name_Name(t *testing.T) {
 	}
 }
 
-func TestName_Name1(t *testing.T) {
+func TestNameName1(t *testing.T) {
 	type fields struct {
 		Name string
 	}
@@ -34,7 +34,7 @@ func TestName_Name1(t *testing.T) {
 		args   args
 		want   string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		n := &Name{
@@ -46,7 +46,7 @@ func TestName_Name1(t *testing.T) {
 	}
 }
 
-func TestName_Name2(t *testing.T) {
+func TestNameName2(t *testing.T) {
 	type fields struct {
 		Name string
 	}
@@ -59,7 +59,7 @@ func TestName_Name2(t *testing.T) {
 		args   args
 		want   string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		n := &Name{
@@ -71,7 +71,7 @@ func TestName_Name2(t *testing.T) {
 	}
 }
 
-func TestName_Name3(t *testing.T) {
+func TestNameName3(t *testing.T) {
 	type fields struct {
 		Name string
 	}
@@ -84,7 +84,7 @@ func TestName_Name3(t *testing.T) {
 		args     args
 		wantName string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		n := &Name{

--- a/testdata/goldens/functions_and_receivers_with_same_names_except_exporting.go
+++ b/testdata/goldens/functions_and_receivers_with_same_names_except_exporting.go
@@ -8,7 +8,7 @@ func TestSameName(t *testing.T) {
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := SameName()
@@ -22,13 +22,13 @@ func TestSameName(t *testing.T) {
 	}
 }
 
-func Test_sameName(t *testing.T) {
+func TestSameName(t *testing.T) {
 	tests := []struct {
 		name    string
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := sameName()
@@ -42,14 +42,14 @@ func Test_sameName(t *testing.T) {
 	}
 }
 
-func TestSameTypeName_SameName(t *testing.T) {
+func TestSameTypeNameSameName(t *testing.T) {
 	tests := []struct {
 		name    string
 		t       *SameTypeName
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t := &SameTypeName{}
@@ -64,14 +64,14 @@ func TestSameTypeName_SameName(t *testing.T) {
 	}
 }
 
-func TestSameTypeName_sameName(t *testing.T) {
+func TestSameTypeNameSameName(t *testing.T) {
 	tests := []struct {
 		name    string
 		t       *SameTypeName
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t := &SameTypeName{}
@@ -86,14 +86,14 @@ func TestSameTypeName_sameName(t *testing.T) {
 	}
 }
 
-func Test_sameTypeName_SameName(t *testing.T) {
+func TestSameTypeNameSameName(t *testing.T) {
 	tests := []struct {
 		name    string
 		t       *sameTypeName
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t := &sameTypeName{}
@@ -108,14 +108,14 @@ func Test_sameTypeName_SameName(t *testing.T) {
 	}
 }
 
-func Test_sameTypeName_sameName(t *testing.T) {
+func TestSameTypeNameSameName(t *testing.T) {
 	tests := []struct {
 		name    string
 		t       *sameTypeName
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t := &sameTypeName{}

--- a/testdata/goldens/io_writer_parameters.go
+++ b/testdata/goldens/io_writer_parameters.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 )
 
-func TestBar_Write(t *testing.T) {
+func TestBarWrite(t *testing.T) {
 	tests := []struct {
 		name    string
 		b       *Bar
 		wantW   string
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		b := &Bar{}
@@ -37,7 +37,7 @@ func TestWrite(t *testing.T) {
 		wantW   string
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		w := &bytes.Buffer{}
@@ -64,7 +64,7 @@ func TestMultiWrite(t *testing.T) {
 		wantW2  string
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		w1 := &bytes.Buffer{}

--- a/testdata/goldens/method_on_a_struct_pointer.go
+++ b/testdata/goldens/method_on_a_struct_pointer.go
@@ -2,7 +2,7 @@ package testdata
 
 import "testing"
 
-func TestBar_Foo7(t *testing.T) {
+func TestBarFoo7(t *testing.T) {
 	type args struct {
 		i int
 	}
@@ -13,7 +13,7 @@ func TestBar_Foo7(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		b := &Bar{}

--- a/testdata/goldens/multiple_functions.go
+++ b/testdata/goldens/multiple_functions.go
@@ -15,7 +15,7 @@ func TestFooFilter(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := FooFilter(tt.args.strs)
@@ -29,7 +29,7 @@ func TestFooFilter(t *testing.T) {
 	}
 }
 
-func TestBar_BarFilter(t *testing.T) {
+func TestBarBarFilter(t *testing.T) {
 	type args struct {
 		i interface{}
 	}
@@ -39,7 +39,7 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		b := &Bar{}
@@ -49,7 +49,7 @@ func TestBar_BarFilter(t *testing.T) {
 	}
 }
 
-func Test_bazFilter(t *testing.T) {
+func TestBazFilter(t *testing.T) {
 	type args struct {
 		f *float64
 	}
@@ -58,7 +58,7 @@ func Test_bazFilter(t *testing.T) {
 		args args
 		want float64
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := bazFilter(tt.args.f); got != tt.want {

--- a/testdata/goldens/multiple_functions_excluding_on_method.go
+++ b/testdata/goldens/multiple_functions_excluding_on_method.go
@@ -15,7 +15,7 @@ func TestFooFilter(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := FooFilter(tt.args.strs)
@@ -29,7 +29,7 @@ func TestFooFilter(t *testing.T) {
 	}
 }
 
-func Test_bazFilter(t *testing.T) {
+func TestBazFilter(t *testing.T) {
 	type args struct {
 		f *float64
 	}
@@ -38,7 +38,7 @@ func Test_bazFilter(t *testing.T) {
 		args args
 		want float64
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := bazFilter(tt.args.f); got != tt.want {

--- a/testdata/goldens/multiple_functions_excluding_on_receiver.go
+++ b/testdata/goldens/multiple_functions_excluding_on_receiver.go
@@ -15,7 +15,7 @@ func TestFooFilter(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := FooFilter(tt.args.strs)
@@ -29,7 +29,7 @@ func TestFooFilter(t *testing.T) {
 	}
 }
 
-func Test_bazFilter(t *testing.T) {
+func TestBazFilter(t *testing.T) {
 	type args struct {
 		f *float64
 	}
@@ -38,7 +38,7 @@ func Test_bazFilter(t *testing.T) {
 		args args
 		want float64
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := bazFilter(tt.args.f); got != tt.want {

--- a/testdata/goldens/multiple_functions_filtering_exported.go
+++ b/testdata/goldens/multiple_functions_filtering_exported.go
@@ -15,7 +15,7 @@ func TestFooFilter(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := FooFilter(tt.args.strs)
@@ -29,7 +29,7 @@ func TestFooFilter(t *testing.T) {
 	}
 }
 
-func TestBar_BarFilter(t *testing.T) {
+func TestBarBarFilter(t *testing.T) {
 	type args struct {
 		i interface{}
 	}
@@ -39,7 +39,7 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		b := &Bar{}

--- a/testdata/goldens/multiple_functions_filtering_exported_with_excl.go
+++ b/testdata/goldens/multiple_functions_filtering_exported_with_excl.go
@@ -2,7 +2,7 @@ package testdata
 
 import "testing"
 
-func TestBar_BarFilter(t *testing.T) {
+func TestBarBarFilter(t *testing.T) {
 	type args struct {
 		i interface{}
 	}
@@ -12,7 +12,7 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		b := &Bar{}

--- a/testdata/goldens/multiple_functions_with_both_only_and_excl.go
+++ b/testdata/goldens/multiple_functions_with_both_only_and_excl.go
@@ -2,7 +2,7 @@ package testdata
 
 import "testing"
 
-func TestBar_BarFilter(t *testing.T) {
+func TestBarBarFilter(t *testing.T) {
 	type args struct {
 		i interface{}
 	}
@@ -12,7 +12,7 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		b := &Bar{}

--- a/testdata/goldens/multiple_functions_with_case-insensitive_excl.go
+++ b/testdata/goldens/multiple_functions_with_case-insensitive_excl.go
@@ -2,7 +2,7 @@ package testdata
 
 import "testing"
 
-func TestBar_BarFilter(t *testing.T) {
+func TestBarBarFilter(t *testing.T) {
 	type args struct {
 		i interface{}
 	}
@@ -12,7 +12,7 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		b := &Bar{}

--- a/testdata/goldens/multiple_functions_with_case-insensitive_only.go
+++ b/testdata/goldens/multiple_functions_with_case-insensitive_only.go
@@ -15,7 +15,7 @@ func TestFooFilter(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := FooFilter(tt.args.strs)
@@ -29,7 +29,7 @@ func TestFooFilter(t *testing.T) {
 	}
 }
 
-func Test_bazFilter(t *testing.T) {
+func TestBazFilter(t *testing.T) {
 	type args struct {
 		f *float64
 	}
@@ -38,7 +38,7 @@ func Test_bazFilter(t *testing.T) {
 		args args
 		want float64
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := bazFilter(tt.args.f); got != tt.want {

--- a/testdata/goldens/multiple_functions_with_excl.go
+++ b/testdata/goldens/multiple_functions_with_excl.go
@@ -2,7 +2,7 @@ package testdata
 
 import "testing"
 
-func TestBar_BarFilter(t *testing.T) {
+func TestBarBarFilter(t *testing.T) {
 	type args struct {
 		i interface{}
 	}
@@ -12,7 +12,7 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		b := &Bar{}

--- a/testdata/goldens/multiple_functions_with_only.go
+++ b/testdata/goldens/multiple_functions_with_only.go
@@ -15,7 +15,7 @@ func TestFooFilter(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := FooFilter(tt.args.strs)
@@ -29,7 +29,7 @@ func TestFooFilter(t *testing.T) {
 	}
 }
 
-func Test_bazFilter(t *testing.T) {
+func TestBazFilter(t *testing.T) {
 	type args struct {
 		f *float64
 	}
@@ -38,7 +38,7 @@ func Test_bazFilter(t *testing.T) {
 		args args
 		want float64
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := bazFilter(tt.args.f); got != tt.want {

--- a/testdata/goldens/multiple_functions_with_only_and_excl_competing.go
+++ b/testdata/goldens/multiple_functions_with_only_and_excl_competing.go
@@ -2,7 +2,7 @@ package testdata
 
 import "testing"
 
-func TestBar_BarFilter(t *testing.T) {
+func TestBarBarFilter(t *testing.T) {
 	type args struct {
 		i interface{}
 	}
@@ -12,7 +12,7 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		b := &Bar{}

--- a/testdata/goldens/multiple_functions_with_only_filtering_on_method.go
+++ b/testdata/goldens/multiple_functions_with_only_filtering_on_method.go
@@ -2,7 +2,7 @@ package testdata
 
 import "testing"
 
-func TestBar_BarFilter(t *testing.T) {
+func TestBarBarFilter(t *testing.T) {
 	type args struct {
 		i interface{}
 	}
@@ -12,7 +12,7 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		b := &Bar{}

--- a/testdata/goldens/multiple_functions_with_only_filtering_on_receiver.go
+++ b/testdata/goldens/multiple_functions_with_only_filtering_on_receiver.go
@@ -2,7 +2,7 @@ package testdata
 
 import "testing"
 
-func TestBar_BarFilter(t *testing.T) {
+func TestBarBarFilter(t *testing.T) {
 	type args struct {
 		i interface{}
 	}
@@ -12,7 +12,7 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		b := &Bar{}

--- a/testdata/goldens/no_init_funcs.go
+++ b/testdata/goldens/no_init_funcs.go
@@ -2,7 +2,7 @@ package testdata
 
 import "testing"
 
-func Test_initFuncStruct_init(t *testing.T) {
+func TestInitFuncStructInit(t *testing.T) {
 	type fields struct {
 		field int
 	}
@@ -11,7 +11,7 @@ func Test_initFuncStruct_init(t *testing.T) {
 		fields fields
 		want   int
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		i := initFuncStruct{
@@ -23,7 +23,7 @@ func Test_initFuncStruct_init(t *testing.T) {
 	}
 }
 
-func Test_initFieldStruct_getInit(t *testing.T) {
+func TestInitFieldStructGetInit(t *testing.T) {
 	type fields struct {
 		init int
 	}
@@ -32,7 +32,7 @@ func Test_initFieldStruct_getInit(t *testing.T) {
 		fields fields
 		want   int
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		i := initFieldStruct{

--- a/testdata/goldens/print_inputs_with_single_argument.go
+++ b/testdata/goldens/print_inputs_with_single_argument.go
@@ -2,7 +2,7 @@ package testdata
 
 import "testing"
 
-func TestBar_Foo7(t *testing.T) {
+func TestBarFoo7(t *testing.T) {
 	type args struct {
 		i int
 	}
@@ -13,7 +13,7 @@ func TestBar_Foo7(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		b := &Bar{}

--- a/testdata/goldens/receiver_is_indirect_imported_struct.go
+++ b/testdata/goldens/receiver_is_indirect_imported_struct.go
@@ -2,12 +2,12 @@ package testdata
 
 import "testing"
 
-func Test_someIndirectImportedStruct_Foo037(t *testing.T) {
+func TestSomeIndirectImportedStructFoo037(t *testing.T) {
 	tests := []struct {
 		name string
 		smtg *someIndirectImportedStruct
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		smtg := &someIndirectImportedStruct{}

--- a/testdata/goldens/receiver_struct_with_fields_with_complex_package_names.go
+++ b/testdata/goldens/receiver_struct_with_fields_with_complex_package_names.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestImporter_Foo35(t *testing.T) {
+func TestImporterFoo35(t *testing.T) {
 	type fields struct {
 		Importer types.Importer
 		Field    *types.Var
@@ -20,7 +20,7 @@ func TestImporter_Foo35(t *testing.T) {
 		args   args
 		want   *types.Var
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		i := &Importer{

--- a/testdata/goldens/receiver_struct_with_reserved_field_names.go
+++ b/testdata/goldens/receiver_struct_with_reserved_field_names.go
@@ -2,7 +2,7 @@ package testdata
 
 import "testing"
 
-func TestReserved_DontFail(t *testing.T) {
+func TestReservedDontFail(t *testing.T) {
 	type fields struct {
 		Name        string
 		Break       string
@@ -36,7 +36,7 @@ func TestReserved_DontFail(t *testing.T) {
 		fields fields
 		want   string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		r := &Reserved{

--- a/testdata/goldens/struct_receiver_with_anonymous_fields.go
+++ b/testdata/goldens/struct_receiver_with_anonymous_fields.go
@@ -2,7 +2,7 @@ package testdata
 
 import "testing"
 
-func TestDoctor_SayHello(t *testing.T) {
+func TestDoctorSayHello(t *testing.T) {
 	type fields struct {
 		Person      *Person
 		ID          string
@@ -18,7 +18,7 @@ func TestDoctor_SayHello(t *testing.T) {
 		args   args
 		want   string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		d := &Doctor{

--- a/testdata/goldens/struct_receiver_with_multiple_fields.go
+++ b/testdata/goldens/struct_receiver_with_multiple_fields.go
@@ -2,7 +2,7 @@ package testdata
 
 import "testing"
 
-func TestPerson_SayHello(t *testing.T) {
+func TestPersonSayHello(t *testing.T) {
 	type fields struct {
 		FirstName string
 		LastName  string
@@ -19,7 +19,7 @@ func TestPerson_SayHello(t *testing.T) {
 		args   args
 		want   string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		p := &Person{

--- a/testdata/goldens/struct_value_method_with_struct_value_return_type.go
+++ b/testdata/goldens/struct_value_method_with_struct_value_return_type.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 )
 
-func TestBar_Foo9(t *testing.T) {
+func TestBarFoo9(t *testing.T) {
 	tests := []struct {
 		name string
 		b    Bar
 		want Bar
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		b := Bar{}

--- a/testdata/goldens/subtest_edition_-_functions_and_receivers_with_same_names_except_exporting.go
+++ b/testdata/goldens/subtest_edition_-_functions_and_receivers_with_same_names_except_exporting.go
@@ -8,7 +8,7 @@ func TestSameName(t *testing.T) {
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -24,13 +24,13 @@ func TestSameName(t *testing.T) {
 	}
 }
 
-func Test_sameName(t *testing.T) {
+func TestSameName(t *testing.T) {
 	tests := []struct {
 		name    string
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -46,14 +46,14 @@ func Test_sameName(t *testing.T) {
 	}
 }
 
-func TestSameTypeName_SameName(t *testing.T) {
+func TestSameTypeNameSameName(t *testing.T) {
 	tests := []struct {
 		name    string
 		t       *SameTypeName
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -70,14 +70,14 @@ func TestSameTypeName_SameName(t *testing.T) {
 	}
 }
 
-func TestSameTypeName_sameName(t *testing.T) {
+func TestSameTypeNameSameName(t *testing.T) {
 	tests := []struct {
 		name    string
 		t       *SameTypeName
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -94,14 +94,14 @@ func TestSameTypeName_sameName(t *testing.T) {
 	}
 }
 
-func Test_sameTypeName_SameName(t *testing.T) {
+func TestSameTypeNameSameName(t *testing.T) {
 	tests := []struct {
 		name    string
 		t       *sameTypeName
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -118,14 +118,14 @@ func Test_sameTypeName_SameName(t *testing.T) {
 	}
 }
 
-func Test_sameTypeName_sameName(t *testing.T) {
+func TestSameTypeNameSameName(t *testing.T) {
 	tests := []struct {
 		name    string
 		t       *sameTypeName
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/testdata/goldens/target_test_file.go
+++ b/testdata/goldens/target_test_file.go
@@ -54,7 +54,7 @@ func wrapToString(in []int) []string {
 	return result
 }
 
-func Test_wrapToString(t *testing.T) {
+func TestWrapToString(t *testing.T) {
 	type args struct {
 		in []int
 	}
@@ -63,7 +63,7 @@ func Test_wrapToString(t *testing.T) {
 		args args
 		want []string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/testdata/goldens/two_different_structs_with_same_method_name.go
+++ b/testdata/goldens/two_different_structs_with_same_method_name.go
@@ -2,13 +2,13 @@ package testdata
 
 import "testing"
 
-func TestBook_Open(t *testing.T) {
+func TestBookOpen(t *testing.T) {
 	tests := []struct {
 		name    string
 		b       *Book
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		b := &Book{}
@@ -18,13 +18,13 @@ func TestBook_Open(t *testing.T) {
 	}
 }
 
-func Test_door_Open(t *testing.T) {
+func TestDoorOpen(t *testing.T) {
 	tests := []struct {
 		name    string
 		d       *door
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		d := &door{}
@@ -34,13 +34,13 @@ func Test_door_Open(t *testing.T) {
 	}
 }
 
-func Test_xml_Open(t *testing.T) {
+func TestXmlOpen(t *testing.T) {
 	tests := []struct {
 		name    string
 		x       *xml
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		x := &xml{}

--- a/testdata/goldens/two_structs_with_same_method_name.go
+++ b/testdata/goldens/two_structs_with_same_method_name.go
@@ -2,13 +2,13 @@ package testdata
 
 import "testing"
 
-func TestCelsius_String(t *testing.T) {
+func TestCelsiusString(t *testing.T) {
 	tests := []struct {
 		name string
 		c    Celsius
 		want string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := tt.c.String(); got != tt.want {
@@ -17,13 +17,13 @@ func TestCelsius_String(t *testing.T) {
 	}
 }
 
-func TestFahrenheit_String(t *testing.T) {
+func TestFahrenheitString(t *testing.T) {
 	tests := []struct {
 		name string
 		f    Fahrenheit
 		want string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := tt.f.String(); got != tt.want {

--- a/testdata/goldens/undefined_types.go
+++ b/testdata/goldens/undefined_types.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestUndefined_Do(t *testing.T) {
+func TestUndefinedDo(t *testing.T) {
 	type args struct {
 		es Something
 	}
@@ -16,7 +16,7 @@ func TestUndefined_Do(t *testing.T) {
 		want    *Unknown
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := tt.u.Do(tt.args.es)

--- a/testdata/goldens/underlying_types.go
+++ b/testdata/goldens/underlying_types.go
@@ -5,13 +5,13 @@ import (
 	"time"
 )
 
-func TestCelsius_ToFahrenheit(t *testing.T) {
+func TestCelsiusToFahrenheit(t *testing.T) {
 	tests := []struct {
 		name string
 		c    Celsius
 		want Fahrenheit
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := tt.c.ToFahrenheit(); got != tt.want {
@@ -29,7 +29,7 @@ func TestHourToSecond(t *testing.T) {
 		args args
 		want time.Duration
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := HourToSecond(tt.args.h); got != tt.want {


### PR DESCRIPTION
Change the gotests `TestName` function to follow the effective Go guide of [MixedCaps](https://golang.org/doc/effective_go.html#mixed-caps). 

This tool generates code that does not follow the Go effective style guide. 

In this change we only change the `TestName` from adding `_` to returning the Title version of the string that was intended for the test name. This give a MixedCaps test name.

Another angle would be to add a func to the Templates `FuncMap` to allow custom templates to replace the `_`s and Title the string in the template. This seems like a change that would best be default since it is following the effective Go guide. 