### PR TITLE
Remove go 1.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 sudo: false
 go:
-  - 1.7.x
   - 1.8.x
   - 1.9.x
   - 1.10.x


### PR DESCRIPTION
It looks like the go 1.7 build is failing with this output:

../../mjibson/esc/embed/embed.go:181: undefined: sort.Slice
The command "go get github.com/mjibson/esc" failed and exited with 2 during .

The most recent commit on mjibson/esc is using a function which is not available on go1.7.

Would you prefer trying to pull a specific version of mjibson/esc or to drop support for go1.7?