### PR TITLE
Restructure test templates to generate tests as suites

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ go:
 before_install:
   - go get github.com/mattn/goveralls
   - go get github.com/mjibson/esc
+  - go get github.com/stretchr/testify/suite
   - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
 script:
   - go test ./...

--- a/gotests.go
+++ b/gotests.go
@@ -114,6 +114,9 @@ func generateTest(src models.Path, files []models.Path, opt *Options) (*Generate
 	if len(funcs) == 0 {
 		return nil, nil
 	}
+
+	h.Suites = generateSuites(funcs)
+
 	b, err := output.Process(h, funcs, &output.Options{
 		PrintInputs: opt.PrintInputs,
 		Subtests:    opt.Subtests,
@@ -127,6 +130,23 @@ func generateTest(src models.Path, files []models.Path, opt *Options) (*Generate
 		Functions: funcs,
 		Output:    b,
 	}, nil
+}
+
+func generateSuites(funcs []*models.Function) []models.Suite {
+	suiteMap := map[string]bool{}
+	suites := []models.Suite{}
+	for _, f := range funcs {
+		suiteName := f.SuiteName()
+		if _, found := suiteMap[suiteName]; suiteName != "" && !found {
+			suites = append(suites, models.Suite{
+				Name:   suiteName,
+				Fields: f.Receiver.Fields,
+			})
+			suiteMap[suiteName] = true
+
+		}
+	}
+	return suites
 }
 
 func parseTestFile(p *goparser.Parser, testPath string, h *models.Header) (*models.Header, []string, error) {

--- a/gotests_test.go
+++ b/gotests_test.go
@@ -286,7 +286,7 @@ func TestGenerateTests(t *testing.T) {
 			},
 			want: mustReadAndFormatGoFile(t, "testdata/goldens/struct_receiver_with_anonymous_fields.go"),
 		}, {
-			name: "io.Writer parameters",
+			name: "io Writer parameters",
 			args: args{
 				srcPath: `testdata/test031.go`,
 			},
@@ -525,7 +525,7 @@ func TestGenerateTests(t *testing.T) {
 			want: mustReadAndFormatGoFile(t, "testdata/goldens/subtest_edition_-_functions_and_receivers_with_same_names_except_exporting.go"),
 		},
 		{
-			name: "Init function",
+			name: "No init funcs",
 			args: args{
 				srcPath: `testdata/init_func.go`,
 			},

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -30,6 +30,10 @@ type Field struct {
 	Index int
 }
 
+const (
+	suiteSuffix = "Suite"
+)
+
 func (f *Field) IsWriter() bool {
 	return f.Type.IsWriter
 }
@@ -130,17 +134,22 @@ func (f *Function) TestName() string {
 	if strings.HasPrefix(f.Name, "Test") {
 		return f.Name
 	}
-	if f.Receiver != nil {
-		receiverType := f.Receiver.Type.Value
-		if unicode.IsLower([]rune(receiverType)[0]) {
-			receiverType = "_" + receiverType
-		}
-		return "Test" + receiverType + "_" + f.Name
-	}
 	if unicode.IsLower([]rune(f.Name)[0]) {
 		return "Test_" + f.Name
 	}
 	return "Test" + f.Name
+}
+
+func (f *Function) SuiteName() string {
+	if f.Receiver == nil {
+		return ""
+	}
+
+	return strings.Title(f.Receiver.Type.Value) + suiteSuffix
+}
+
+func (f *Function) HasSuiteName() bool {
+	return f.SuiteName() != ""
 }
 
 func (f *Function) IsNaked() bool {
@@ -156,6 +165,12 @@ type Header struct {
 	Package  string
 	Imports  []*Import
 	Code     []byte
+	Suites   []Suite
+}
+
+type Suite struct {
+	Name   string
+	Fields []*Field
 }
 
 type Path string

--- a/internal/render/templates/function.tmpl
+++ b/internal/render/templates/function.tmpl
@@ -1,7 +1,14 @@
 {{define "function"}}
 {{- $f := .}}
 
-func {{.TestName}}(t *testing.T) {
+{{- if .HasSuiteName}}
+func (s *{{.SuiteName}}) {{.TestName}}(){
+{{- end}}
+
+{{- if not .HasSuiteName}}
+func {{.TestName}}(t *testing.T){
+{{- end}}
+
 	{{- with .Receiver}}
 		{{- if .IsStruct}}
 			{{- if .Fields}}
@@ -41,6 +48,9 @@ func {{.TestName}}(t *testing.T) {
 	}{
 		// TODO: Add test cases.
 	}
+	{{- if .HasSuiteName}}
+	t := s.T()
+	{{- end}}
 	for {{if not .IsNaked}} _, tt := {{end}} range tests {
         {{- if .Subtests }}t.Run(tt.name, func(t *testing.T) { {{- end -}}
 			{{- with .Receiver}}

--- a/internal/render/templates/header.tmpl
+++ b/internal/render/templates/header.tmpl
@@ -1,4 +1,5 @@
 {{define "header"}}
+{{- $h := .}}
 {{range .Comments}}{{.}}
 {{end -}}
 package {{.Package}}
@@ -7,4 +8,5 @@ import (
 {{range .Imports}}{{.Name}} {{.Path}}
 {{end}}
 )
+{{template "suiteheader" $h}}
 {{end}}

--- a/internal/render/templates/suiteheader.tmpl
+++ b/internal/render/templates/suiteheader.tmpl
@@ -1,0 +1,24 @@
+{{define "suiteheader"}}
+{{- range .Suites}}
+
+type {{.Name}} struct {
+    suite.Suite
+    {{- with .Fields}}
+        {{- range .}}
+            {{Field .}} {{.Type}}
+        {{- end}}
+    {{- end}}
+}
+
+func Test{{.Name}}(t *testing.T) {
+    suite.Run(t, new({{.Name}}))
+}
+
+func (s *{{.Name}}) SetupTest()    {}
+func (s *{{.Name}}) TearDownTest() {}
+
+func (s *{{.Name}}) SetupSuite()    {}
+func (s *{{.Name}}) TearDownSuite() {}
+
+{{- end}}
+{{end}}

--- a/testdata/goldens/custom_importer_fails.go
+++ b/testdata/goldens/custom_importer_fails.go
@@ -3,7 +3,23 @@ package testdata
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
 )
+
+type BarSuite struct {
+	suite.Suite
+}
+
+func TestBarSuite(t *testing.T) {
+	suite.Run(t, new(BarSuite))
+}
+
+func (s *BarSuite) SetupTest()    {}
+func (s *BarSuite) TearDownTest() {}
+
+func (s *BarSuite) SetupSuite()    {}
+func (s *BarSuite) TearDownSuite() {}
 
 func TestFooFilter(t *testing.T) {
 	type args struct {
@@ -15,7 +31,7 @@ func TestFooFilter(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := FooFilter(tt.args.strs)
@@ -29,7 +45,7 @@ func TestFooFilter(t *testing.T) {
 	}
 }
 
-func TestBar_BarFilter(t *testing.T) {
+func (s *BarSuite) TestBarFilter() {
 	type args struct {
 		i interface{}
 	}
@@ -39,8 +55,9 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		b := &Bar{}
 		if err := b.BarFilter(tt.args.i); (err != nil) != tt.wantErr {
@@ -58,7 +75,7 @@ func Test_bazFilter(t *testing.T) {
 		args args
 		want float64
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := bazFilter(tt.args.f); got != tt.want {

--- a/testdata/goldens/different_packages_in_same_directory_-_part_1.go
+++ b/testdata/goldens/different_packages_in_same_directory_-_part_1.go
@@ -1,8 +1,27 @@
 package bar
 
-import "testing"
+import (
+	"testing"
 
-func TestBar_Bar(t *testing.T) {
+	"github.com/stretchr/testify/suite"
+)
+
+type BarSuite struct {
+	suite.Suite
+	Foo string
+}
+
+func TestBarSuite(t *testing.T) {
+	suite.Run(t, new(BarSuite))
+}
+
+func (s *BarSuite) SetupTest()    {}
+func (s *BarSuite) TearDownTest() {}
+
+func (s *BarSuite) SetupSuite()    {}
+func (s *BarSuite) TearDownSuite() {}
+
+func (s *BarSuite) TestBar() {
 	type fields struct {
 		Foo string
 	}
@@ -15,8 +34,9 @@ func TestBar_Bar(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		b := &Bar{
 			Foo: tt.fields.Foo,

--- a/testdata/goldens/different_packages_in_same_directory_-_part_2.go
+++ b/testdata/goldens/different_packages_in_same_directory_-_part_2.go
@@ -1,8 +1,27 @@
 package foo
 
-import "testing"
+import (
+	"testing"
 
-func TestFoo_Foo(t *testing.T) {
+	"github.com/stretchr/testify/suite"
+)
+
+type FooSuite struct {
+	suite.Suite
+	Bar string
+}
+
+func TestFooSuite(t *testing.T) {
+	suite.Run(t, new(FooSuite))
+}
+
+func (s *FooSuite) SetupTest()    {}
+func (s *FooSuite) TearDownTest() {}
+
+func (s *FooSuite) SetupSuite()    {}
+func (s *FooSuite) TearDownSuite() {}
+
+func (s *FooSuite) TestFoo() {
 	type fields struct {
 		Bar string
 	}
@@ -15,8 +34,9 @@ func TestFoo_Foo(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		f := &Foo{
 			Bar: tt.fields.Bar,

--- a/testdata/goldens/existing_test_file.go
+++ b/testdata/goldens/existing_test_file.go
@@ -3,7 +3,23 @@ package testdata
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
 )
+
+type BarSuite struct {
+	suite.Suite
+}
+
+func TestBarSuite(t *testing.T) {
+	suite.Run(t, new(BarSuite))
+}
+
+func (s *BarSuite) SetupTest()    {}
+func (s *BarSuite) TearDownTest() {}
+
+func (s *BarSuite) SetupSuite()    {}
+func (s *BarSuite) TearDownSuite() {}
 
 func TestBarBar100(t *testing.T) {
 	tests := []struct {
@@ -55,7 +71,7 @@ func TestFoo100(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := Foo100(tt.args.strs)
@@ -69,7 +85,7 @@ func TestFoo100(t *testing.T) {
 	}
 }
 
-func TestBar_Bar100(t *testing.T) {
+func (s *BarSuite) TestBar100() {
 	type args struct {
 		i interface{}
 	}
@@ -79,8 +95,9 @@ func TestBar_Bar100(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		b := &Bar{}
 		if err := b.Bar100(tt.args.i); (err != nil) != tt.wantErr {
@@ -98,7 +115,7 @@ func Test_baz100(t *testing.T) {
 		args args
 		want float64
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := baz100(tt.args.f); got != tt.want {

--- a/testdata/goldens/functions_and_methods_with_name_receivers_parameters_and_results.go
+++ b/testdata/goldens/functions_and_methods_with_name_receivers_parameters_and_results.go
@@ -1,8 +1,26 @@
 package testdata
 
-import "testing"
+import (
+	"testing"
 
-func Test_name_Name(t *testing.T) {
+	"github.com/stretchr/testify/suite"
+)
+
+type NameSuite struct {
+	suite.Suite
+}
+
+func TestNameSuite(t *testing.T) {
+	suite.Run(t, new(NameSuite))
+}
+
+func (s *NameSuite) SetupTest()    {}
+func (s *NameSuite) TearDownTest() {}
+
+func (s *NameSuite) SetupSuite()    {}
+func (s *NameSuite) TearDownSuite() {}
+
+func (s *NameSuite) TestName() {
 	type args struct {
 		n string
 	}
@@ -12,8 +30,9 @@ func Test_name_Name(t *testing.T) {
 		args args
 		want string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		if got := tt.n.Name(tt.args.n); got != tt.want {
 			t.Errorf("%q. name.Name() = %v, want %v", tt.name, got, tt.want)
@@ -21,7 +40,7 @@ func Test_name_Name(t *testing.T) {
 	}
 }
 
-func TestName_Name1(t *testing.T) {
+func (s *NameSuite) TestName1() {
 	type fields struct {
 		Name string
 	}
@@ -34,8 +53,9 @@ func TestName_Name1(t *testing.T) {
 		args   args
 		want   string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		n := &Name{
 			Name: tt.fields.Name,
@@ -46,7 +66,7 @@ func TestName_Name1(t *testing.T) {
 	}
 }
 
-func TestName_Name2(t *testing.T) {
+func (s *NameSuite) TestName2() {
 	type fields struct {
 		Name string
 	}
@@ -59,8 +79,9 @@ func TestName_Name2(t *testing.T) {
 		args   args
 		want   string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		n := &Name{
 			Name: tt.fields.Name,
@@ -71,7 +92,7 @@ func TestName_Name2(t *testing.T) {
 	}
 }
 
-func TestName_Name3(t *testing.T) {
+func (s *NameSuite) TestName3() {
 	type fields struct {
 		Name string
 	}
@@ -84,8 +105,9 @@ func TestName_Name3(t *testing.T) {
 		args     args
 		wantName string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		n := &Name{
 			Name: tt.fields.Name,

--- a/testdata/goldens/functions_and_receivers_with_same_names_except_exporting.go
+++ b/testdata/goldens/functions_and_receivers_with_same_names_except_exporting.go
@@ -1,6 +1,24 @@
 package testdata
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type SameTypeNameSuite struct {
+	suite.Suite
+}
+
+func TestSameTypeNameSuite(t *testing.T) {
+	suite.Run(t, new(SameTypeNameSuite))
+}
+
+func (s *SameTypeNameSuite) SetupTest()    {}
+func (s *SameTypeNameSuite) TearDownTest() {}
+
+func (s *SameTypeNameSuite) SetupSuite()    {}
+func (s *SameTypeNameSuite) TearDownSuite() {}
 
 func TestSameName(t *testing.T) {
 	tests := []struct {
@@ -8,7 +26,7 @@ func TestSameName(t *testing.T) {
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := SameName()
@@ -28,7 +46,7 @@ func Test_sameName(t *testing.T) {
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := sameName()
@@ -42,15 +60,16 @@ func Test_sameName(t *testing.T) {
 	}
 }
 
-func TestSameTypeName_SameName(t *testing.T) {
+func (s *SameTypeNameSuite) TestSameName() {
 	tests := []struct {
 		name    string
 		t       *SameTypeName
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		t := &SameTypeName{}
 		got, err := t.SameName()
@@ -64,15 +83,16 @@ func TestSameTypeName_SameName(t *testing.T) {
 	}
 }
 
-func TestSameTypeName_sameName(t *testing.T) {
+func (s *SameTypeNameSuite) Test_sameName() {
 	tests := []struct {
 		name    string
 		t       *SameTypeName
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		t := &SameTypeName{}
 		got, err := t.sameName()
@@ -86,15 +106,16 @@ func TestSameTypeName_sameName(t *testing.T) {
 	}
 }
 
-func Test_sameTypeName_SameName(t *testing.T) {
+func (s *SameTypeNameSuite) TestSameName() {
 	tests := []struct {
 		name    string
 		t       *sameTypeName
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		t := &sameTypeName{}
 		got, err := t.SameName()
@@ -108,15 +129,16 @@ func Test_sameTypeName_SameName(t *testing.T) {
 	}
 }
 
-func Test_sameTypeName_sameName(t *testing.T) {
+func (s *SameTypeNameSuite) Test_sameName() {
 	tests := []struct {
 		name    string
 		t       *sameTypeName
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		t := &sameTypeName{}
 		got, err := t.sameName()

--- a/testdata/goldens/io_writer_parameters.go
+++ b/testdata/goldens/io_writer_parameters.go
@@ -3,17 +3,34 @@ package testdata
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
 )
 
-func TestBar_Write(t *testing.T) {
+type BarSuite struct {
+	suite.Suite
+}
+
+func TestBarSuite(t *testing.T) {
+	suite.Run(t, new(BarSuite))
+}
+
+func (s *BarSuite) SetupTest()    {}
+func (s *BarSuite) TearDownTest() {}
+
+func (s *BarSuite) SetupSuite()    {}
+func (s *BarSuite) TearDownSuite() {}
+
+func (s *BarSuite) TestWrite() {
 	tests := []struct {
 		name    string
 		b       *Bar
 		wantW   string
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		b := &Bar{}
 		w := &bytes.Buffer{}
@@ -37,7 +54,7 @@ func TestWrite(t *testing.T) {
 		wantW   string
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		w := &bytes.Buffer{}
@@ -64,7 +81,7 @@ func TestMultiWrite(t *testing.T) {
 		wantW2  string
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		w1 := &bytes.Buffer{}

--- a/testdata/goldens/method_on_a_struct_pointer.go
+++ b/testdata/goldens/method_on_a_struct_pointer.go
@@ -1,8 +1,26 @@
 package testdata
 
-import "testing"
+import (
+	"testing"
 
-func TestBar_Foo7(t *testing.T) {
+	"github.com/stretchr/testify/suite"
+)
+
+type BarSuite struct {
+	suite.Suite
+}
+
+func TestBarSuite(t *testing.T) {
+	suite.Run(t, new(BarSuite))
+}
+
+func (s *BarSuite) SetupTest()    {}
+func (s *BarSuite) TearDownTest() {}
+
+func (s *BarSuite) SetupSuite()    {}
+func (s *BarSuite) TearDownSuite() {}
+
+func (s *BarSuite) TestFoo7() {
 	type args struct {
 		i int
 	}
@@ -13,8 +31,9 @@ func TestBar_Foo7(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		b := &Bar{}
 		got, err := b.Foo7(tt.args.i)

--- a/testdata/goldens/multiple_functions.go
+++ b/testdata/goldens/multiple_functions.go
@@ -3,7 +3,23 @@ package testdata
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
 )
+
+type BarSuite struct {
+	suite.Suite
+}
+
+func TestBarSuite(t *testing.T) {
+	suite.Run(t, new(BarSuite))
+}
+
+func (s *BarSuite) SetupTest()    {}
+func (s *BarSuite) TearDownTest() {}
+
+func (s *BarSuite) SetupSuite()    {}
+func (s *BarSuite) TearDownSuite() {}
 
 func TestFooFilter(t *testing.T) {
 	type args struct {
@@ -15,7 +31,7 @@ func TestFooFilter(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := FooFilter(tt.args.strs)
@@ -29,7 +45,7 @@ func TestFooFilter(t *testing.T) {
 	}
 }
 
-func TestBar_BarFilter(t *testing.T) {
+func (s *BarSuite) TestBarFilter() {
 	type args struct {
 		i interface{}
 	}
@@ -39,8 +55,9 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		b := &Bar{}
 		if err := b.BarFilter(tt.args.i); (err != nil) != tt.wantErr {
@@ -58,7 +75,7 @@ func Test_bazFilter(t *testing.T) {
 		args args
 		want float64
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := bazFilter(tt.args.f); got != tt.want {

--- a/testdata/goldens/multiple_functions_filtering_exported.go
+++ b/testdata/goldens/multiple_functions_filtering_exported.go
@@ -3,7 +3,23 @@ package testdata
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
 )
+
+type BarSuite struct {
+	suite.Suite
+}
+
+func TestBarSuite(t *testing.T) {
+	suite.Run(t, new(BarSuite))
+}
+
+func (s *BarSuite) SetupTest()    {}
+func (s *BarSuite) TearDownTest() {}
+
+func (s *BarSuite) SetupSuite()    {}
+func (s *BarSuite) TearDownSuite() {}
 
 func TestFooFilter(t *testing.T) {
 	type args struct {
@@ -15,7 +31,7 @@ func TestFooFilter(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := FooFilter(tt.args.strs)
@@ -29,7 +45,7 @@ func TestFooFilter(t *testing.T) {
 	}
 }
 
-func TestBar_BarFilter(t *testing.T) {
+func (s *BarSuite) TestBarFilter() {
 	type args struct {
 		i interface{}
 	}
@@ -39,8 +55,9 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		b := &Bar{}
 		if err := b.BarFilter(tt.args.i); (err != nil) != tt.wantErr {

--- a/testdata/goldens/multiple_functions_filtering_exported_with_excl.go
+++ b/testdata/goldens/multiple_functions_filtering_exported_with_excl.go
@@ -1,8 +1,26 @@
 package testdata
 
-import "testing"
+import (
+	"testing"
 
-func TestBar_BarFilter(t *testing.T) {
+	"github.com/stretchr/testify/suite"
+)
+
+type BarSuite struct {
+	suite.Suite
+}
+
+func TestBarSuite(t *testing.T) {
+	suite.Run(t, new(BarSuite))
+}
+
+func (s *BarSuite) SetupTest()    {}
+func (s *BarSuite) TearDownTest() {}
+
+func (s *BarSuite) SetupSuite()    {}
+func (s *BarSuite) TearDownSuite() {}
+
+func (s *BarSuite) TestBarFilter() {
 	type args struct {
 		i interface{}
 	}
@@ -12,8 +30,9 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		b := &Bar{}
 		if err := b.BarFilter(tt.args.i); (err != nil) != tt.wantErr {

--- a/testdata/goldens/multiple_functions_with_both_only_and_excl.go
+++ b/testdata/goldens/multiple_functions_with_both_only_and_excl.go
@@ -1,8 +1,26 @@
 package testdata
 
-import "testing"
+import (
+	"testing"
 
-func TestBar_BarFilter(t *testing.T) {
+	"github.com/stretchr/testify/suite"
+)
+
+type BarSuite struct {
+	suite.Suite
+}
+
+func TestBarSuite(t *testing.T) {
+	suite.Run(t, new(BarSuite))
+}
+
+func (s *BarSuite) SetupTest()    {}
+func (s *BarSuite) TearDownTest() {}
+
+func (s *BarSuite) SetupSuite()    {}
+func (s *BarSuite) TearDownSuite() {}
+
+func (s *BarSuite) TestBarFilter() {
 	type args struct {
 		i interface{}
 	}
@@ -12,8 +30,9 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		b := &Bar{}
 		if err := b.BarFilter(tt.args.i); (err != nil) != tt.wantErr {

--- a/testdata/goldens/multiple_functions_with_case-insensitive_excl.go
+++ b/testdata/goldens/multiple_functions_with_case-insensitive_excl.go
@@ -1,8 +1,26 @@
 package testdata
 
-import "testing"
+import (
+	"testing"
 
-func TestBar_BarFilter(t *testing.T) {
+	"github.com/stretchr/testify/suite"
+)
+
+type BarSuite struct {
+	suite.Suite
+}
+
+func TestBarSuite(t *testing.T) {
+	suite.Run(t, new(BarSuite))
+}
+
+func (s *BarSuite) SetupTest()    {}
+func (s *BarSuite) TearDownTest() {}
+
+func (s *BarSuite) SetupSuite()    {}
+func (s *BarSuite) TearDownSuite() {}
+
+func (s *BarSuite) TestBarFilter() {
 	type args struct {
 		i interface{}
 	}
@@ -12,8 +30,9 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		b := &Bar{}
 		if err := b.BarFilter(tt.args.i); (err != nil) != tt.wantErr {

--- a/testdata/goldens/multiple_functions_with_excl.go
+++ b/testdata/goldens/multiple_functions_with_excl.go
@@ -1,8 +1,26 @@
 package testdata
 
-import "testing"
+import (
+	"testing"
 
-func TestBar_BarFilter(t *testing.T) {
+	"github.com/stretchr/testify/suite"
+)
+
+type BarSuite struct {
+	suite.Suite
+}
+
+func TestBarSuite(t *testing.T) {
+	suite.Run(t, new(BarSuite))
+}
+
+func (s *BarSuite) SetupTest()    {}
+func (s *BarSuite) TearDownTest() {}
+
+func (s *BarSuite) SetupSuite()    {}
+func (s *BarSuite) TearDownSuite() {}
+
+func (s *BarSuite) TestBarFilter() {
 	type args struct {
 		i interface{}
 	}
@@ -12,8 +30,9 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		b := &Bar{}
 		if err := b.BarFilter(tt.args.i); (err != nil) != tt.wantErr {

--- a/testdata/goldens/multiple_functions_with_only_and_excl_competing.go
+++ b/testdata/goldens/multiple_functions_with_only_and_excl_competing.go
@@ -1,8 +1,26 @@
 package testdata
 
-import "testing"
+import (
+	"testing"
 
-func TestBar_BarFilter(t *testing.T) {
+	"github.com/stretchr/testify/suite"
+)
+
+type BarSuite struct {
+	suite.Suite
+}
+
+func TestBarSuite(t *testing.T) {
+	suite.Run(t, new(BarSuite))
+}
+
+func (s *BarSuite) SetupTest()    {}
+func (s *BarSuite) TearDownTest() {}
+
+func (s *BarSuite) SetupSuite()    {}
+func (s *BarSuite) TearDownSuite() {}
+
+func (s *BarSuite) TestBarFilter() {
 	type args struct {
 		i interface{}
 	}
@@ -12,8 +30,9 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		b := &Bar{}
 		if err := b.BarFilter(tt.args.i); (err != nil) != tt.wantErr {

--- a/testdata/goldens/multiple_functions_with_only_filtering_on_method.go
+++ b/testdata/goldens/multiple_functions_with_only_filtering_on_method.go
@@ -1,8 +1,26 @@
 package testdata
 
-import "testing"
+import (
+	"testing"
 
-func TestBar_BarFilter(t *testing.T) {
+	"github.com/stretchr/testify/suite"
+)
+
+type BarSuite struct {
+	suite.Suite
+}
+
+func TestBarSuite(t *testing.T) {
+	suite.Run(t, new(BarSuite))
+}
+
+func (s *BarSuite) SetupTest()    {}
+func (s *BarSuite) TearDownTest() {}
+
+func (s *BarSuite) SetupSuite()    {}
+func (s *BarSuite) TearDownSuite() {}
+
+func (s *BarSuite) TestBarFilter() {
 	type args struct {
 		i interface{}
 	}
@@ -12,8 +30,9 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		b := &Bar{}
 		if err := b.BarFilter(tt.args.i); (err != nil) != tt.wantErr {

--- a/testdata/goldens/multiple_functions_with_only_filtering_on_receiver.go
+++ b/testdata/goldens/multiple_functions_with_only_filtering_on_receiver.go
@@ -1,8 +1,26 @@
 package testdata
 
-import "testing"
+import (
+	"testing"
 
-func TestBar_BarFilter(t *testing.T) {
+	"github.com/stretchr/testify/suite"
+)
+
+type BarSuite struct {
+	suite.Suite
+}
+
+func TestBarSuite(t *testing.T) {
+	suite.Run(t, new(BarSuite))
+}
+
+func (s *BarSuite) SetupTest()    {}
+func (s *BarSuite) TearDownTest() {}
+
+func (s *BarSuite) SetupSuite()    {}
+func (s *BarSuite) TearDownSuite() {}
+
+func (s *BarSuite) TestBarFilter() {
 	type args struct {
 		i interface{}
 	}
@@ -12,8 +30,9 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		b := &Bar{}
 		if err := b.BarFilter(tt.args.i); (err != nil) != tt.wantErr {

--- a/testdata/goldens/no_init_funcs.go
+++ b/testdata/goldens/no_init_funcs.go
@@ -1,8 +1,42 @@
 package testdata
 
-import "testing"
+import (
+	"testing"
 
-func Test_initFuncStruct_init(t *testing.T) {
+	"github.com/stretchr/testify/suite"
+)
+
+type InitFuncStructSuite struct {
+	suite.Suite
+	field int
+}
+
+func TestInitFuncStructSuite(t *testing.T) {
+	suite.Run(t, new(InitFuncStructSuite))
+}
+
+func (s *InitFuncStructSuite) SetupTest()    {}
+func (s *InitFuncStructSuite) TearDownTest() {}
+
+func (s *InitFuncStructSuite) SetupSuite()    {}
+func (s *InitFuncStructSuite) TearDownSuite() {}
+
+type InitFieldStructSuite struct {
+	suite.Suite
+	init int
+}
+
+func TestInitFieldStructSuite(t *testing.T) {
+	suite.Run(t, new(InitFieldStructSuite))
+}
+
+func (s *InitFieldStructSuite) SetupTest()    {}
+func (s *InitFieldStructSuite) TearDownTest() {}
+
+func (s *InitFieldStructSuite) SetupSuite()    {}
+func (s *InitFieldStructSuite) TearDownSuite() {}
+
+func (s *InitFuncStructSuite) Test_init() {
 	type fields struct {
 		field int
 	}
@@ -11,8 +45,9 @@ func Test_initFuncStruct_init(t *testing.T) {
 		fields fields
 		want   int
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		i := initFuncStruct{
 			field: tt.fields.field,
@@ -23,7 +58,7 @@ func Test_initFuncStruct_init(t *testing.T) {
 	}
 }
 
-func Test_initFieldStruct_getInit(t *testing.T) {
+func (s *InitFieldStructSuite) Test_getInit() {
 	type fields struct {
 		init int
 	}
@@ -32,8 +67,9 @@ func Test_initFieldStruct_getInit(t *testing.T) {
 		fields fields
 		want   int
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		i := initFieldStruct{
 			init: tt.fields.init,

--- a/testdata/goldens/print_inputs_with_single_argument.go
+++ b/testdata/goldens/print_inputs_with_single_argument.go
@@ -1,8 +1,26 @@
 package testdata
 
-import "testing"
+import (
+	"testing"
 
-func TestBar_Foo7(t *testing.T) {
+	"github.com/stretchr/testify/suite"
+)
+
+type BarSuite struct {
+	suite.Suite
+}
+
+func TestBarSuite(t *testing.T) {
+	suite.Run(t, new(BarSuite))
+}
+
+func (s *BarSuite) SetupTest()    {}
+func (s *BarSuite) TearDownTest() {}
+
+func (s *BarSuite) SetupSuite()    {}
+func (s *BarSuite) TearDownSuite() {}
+
+func (s *BarSuite) TestFoo7() {
 	type args struct {
 		i int
 	}
@@ -13,8 +31,9 @@ func TestBar_Foo7(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		b := &Bar{}
 		got, err := b.Foo7(tt.args.i)

--- a/testdata/goldens/receiver_is_indirect_imported_struct.go
+++ b/testdata/goldens/receiver_is_indirect_imported_struct.go
@@ -1,14 +1,33 @@
 package testdata
 
-import "testing"
+import (
+	"testing"
 
-func Test_someIndirectImportedStruct_Foo037(t *testing.T) {
+	"github.com/stretchr/testify/suite"
+)
+
+type SomeIndirectImportedStructSuite struct {
+	suite.Suite
+}
+
+func TestSomeIndirectImportedStructSuite(t *testing.T) {
+	suite.Run(t, new(SomeIndirectImportedStructSuite))
+}
+
+func (s *SomeIndirectImportedStructSuite) SetupTest()    {}
+func (s *SomeIndirectImportedStructSuite) TearDownTest() {}
+
+func (s *SomeIndirectImportedStructSuite) SetupSuite()    {}
+func (s *SomeIndirectImportedStructSuite) TearDownSuite() {}
+
+func (s *SomeIndirectImportedStructSuite) TestFoo037() {
 	tests := []struct {
 		name string
 		smtg *someIndirectImportedStruct
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		smtg := &someIndirectImportedStruct{}
 		smtg.Foo037()

--- a/testdata/goldens/receiver_struct_with_fields_with_complex_package_names.go
+++ b/testdata/goldens/receiver_struct_with_fields_with_complex_package_names.go
@@ -4,9 +4,27 @@ import (
 	"go/types"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
 )
 
-func TestImporter_Foo35(t *testing.T) {
+type ImporterSuite struct {
+	suite.Suite
+	Importer types.Importer
+	Field    *types.Var
+}
+
+func TestImporterSuite(t *testing.T) {
+	suite.Run(t, new(ImporterSuite))
+}
+
+func (s *ImporterSuite) SetupTest()    {}
+func (s *ImporterSuite) TearDownTest() {}
+
+func (s *ImporterSuite) SetupSuite()    {}
+func (s *ImporterSuite) TearDownSuite() {}
+
+func (s *ImporterSuite) TestFoo35() {
 	type fields struct {
 		Importer types.Importer
 		Field    *types.Var
@@ -20,8 +38,9 @@ func TestImporter_Foo35(t *testing.T) {
 		args   args
 		want   *types.Var
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		i := &Importer{
 			Importer: tt.fields.Importer,

--- a/testdata/goldens/receiver_struct_with_reserved_field_names.go
+++ b/testdata/goldens/receiver_struct_with_reserved_field_names.go
@@ -1,8 +1,52 @@
 package testdata
 
-import "testing"
+import (
+	"testing"
 
-func TestReserved_DontFail(t *testing.T) {
+	"github.com/stretchr/testify/suite"
+)
+
+type ReservedSuite struct {
+	suite.Suite
+	Name        string
+	Break       string
+	Default     string
+	Func        string
+	Interface   string
+	Select      string
+	Case        string
+	Defer       string
+	Go          string
+	Map         string
+	Struct      string
+	Chan        string
+	Else        string
+	Goto        string
+	Package     string
+	Switch      string
+	Const       string
+	Fallthrough string
+	If          string
+	Range       string
+	Type        string
+	Continue    string
+	For         string
+	Import      string
+	Return      string
+	Var         string
+}
+
+func TestReservedSuite(t *testing.T) {
+	suite.Run(t, new(ReservedSuite))
+}
+
+func (s *ReservedSuite) SetupTest()    {}
+func (s *ReservedSuite) TearDownTest() {}
+
+func (s *ReservedSuite) SetupSuite()    {}
+func (s *ReservedSuite) TearDownSuite() {}
+
+func (s *ReservedSuite) TestDontFail() {
 	type fields struct {
 		Name        string
 		Break       string
@@ -36,8 +80,9 @@ func TestReserved_DontFail(t *testing.T) {
 		fields fields
 		want   string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		r := &Reserved{
 			Name:        tt.fields.Name,

--- a/testdata/goldens/struct_receiver_with_anonymous_fields.go
+++ b/testdata/goldens/struct_receiver_with_anonymous_fields.go
@@ -1,8 +1,30 @@
 package testdata
 
-import "testing"
+import (
+	"testing"
 
-func TestDoctor_SayHello(t *testing.T) {
+	"github.com/stretchr/testify/suite"
+)
+
+type DoctorSuite struct {
+	suite.Suite
+	Person      *Person
+	ID          string
+	numPatients int
+	string      string
+}
+
+func TestDoctorSuite(t *testing.T) {
+	suite.Run(t, new(DoctorSuite))
+}
+
+func (s *DoctorSuite) SetupTest()    {}
+func (s *DoctorSuite) TearDownTest() {}
+
+func (s *DoctorSuite) SetupSuite()    {}
+func (s *DoctorSuite) TearDownSuite() {}
+
+func (s *DoctorSuite) TestSayHello() {
 	type fields struct {
 		Person      *Person
 		ID          string
@@ -18,8 +40,9 @@ func TestDoctor_SayHello(t *testing.T) {
 		args   args
 		want   string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		d := &Doctor{
 			Person:      tt.fields.Person,

--- a/testdata/goldens/struct_receiver_with_multiple_fields.go
+++ b/testdata/goldens/struct_receiver_with_multiple_fields.go
@@ -1,8 +1,31 @@
 package testdata
 
-import "testing"
+import (
+	"testing"
 
-func TestPerson_SayHello(t *testing.T) {
+	"github.com/stretchr/testify/suite"
+)
+
+type PersonSuite struct {
+	suite.Suite
+	FirstName string
+	LastName  string
+	Age       int
+	Gender    string
+	Siblings  []*Person
+}
+
+func TestPersonSuite(t *testing.T) {
+	suite.Run(t, new(PersonSuite))
+}
+
+func (s *PersonSuite) SetupTest()    {}
+func (s *PersonSuite) TearDownTest() {}
+
+func (s *PersonSuite) SetupSuite()    {}
+func (s *PersonSuite) TearDownSuite() {}
+
+func (s *PersonSuite) TestSayHello() {
 	type fields struct {
 		FirstName string
 		LastName  string
@@ -19,8 +42,9 @@ func TestPerson_SayHello(t *testing.T) {
 		args   args
 		want   string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		p := &Person{
 			FirstName: tt.fields.FirstName,

--- a/testdata/goldens/struct_value_method_with_struct_value_return_type.go
+++ b/testdata/goldens/struct_value_method_with_struct_value_return_type.go
@@ -3,16 +3,33 @@ package testdata
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
 )
 
-func TestBar_Foo9(t *testing.T) {
+type BarSuite struct {
+	suite.Suite
+}
+
+func TestBarSuite(t *testing.T) {
+	suite.Run(t, new(BarSuite))
+}
+
+func (s *BarSuite) SetupTest()    {}
+func (s *BarSuite) TearDownTest() {}
+
+func (s *BarSuite) SetupSuite()    {}
+func (s *BarSuite) TearDownSuite() {}
+
+func (s *BarSuite) TestFoo9() {
 	tests := []struct {
 		name string
 		b    Bar
 		want Bar
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		b := Bar{}
 		if got := b.Foo9(); !reflect.DeepEqual(got, tt.want) {

--- a/testdata/goldens/subtest_edition_-_functions_and_receivers_with_same_names_except_exporting.go
+++ b/testdata/goldens/subtest_edition_-_functions_and_receivers_with_same_names_except_exporting.go
@@ -1,6 +1,24 @@
 package testdata
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type SameTypeNameSuite struct {
+	suite.Suite
+}
+
+func TestSameTypeNameSuite(t *testing.T) {
+	suite.Run(t, new(SameTypeNameSuite))
+}
+
+func (s *SameTypeNameSuite) SetupTest()    {}
+func (s *SameTypeNameSuite) TearDownTest() {}
+
+func (s *SameTypeNameSuite) SetupSuite()    {}
+func (s *SameTypeNameSuite) TearDownSuite() {}
 
 func TestSameName(t *testing.T) {
 	tests := []struct {
@@ -8,7 +26,7 @@ func TestSameName(t *testing.T) {
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -30,7 +48,7 @@ func Test_sameName(t *testing.T) {
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -46,15 +64,16 @@ func Test_sameName(t *testing.T) {
 	}
 }
 
-func TestSameTypeName_SameName(t *testing.T) {
+func (s *SameTypeNameSuite) TestSameName() {
 	tests := []struct {
 		name    string
 		t       *SameTypeName
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t := &SameTypeName{}
@@ -70,15 +89,16 @@ func TestSameTypeName_SameName(t *testing.T) {
 	}
 }
 
-func TestSameTypeName_sameName(t *testing.T) {
+func (s *SameTypeNameSuite) Test_sameName() {
 	tests := []struct {
 		name    string
 		t       *SameTypeName
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t := &SameTypeName{}
@@ -94,15 +114,16 @@ func TestSameTypeName_sameName(t *testing.T) {
 	}
 }
 
-func Test_sameTypeName_SameName(t *testing.T) {
+func (s *SameTypeNameSuite) TestSameName() {
 	tests := []struct {
 		name    string
 		t       *sameTypeName
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t := &sameTypeName{}
@@ -118,15 +139,16 @@ func Test_sameTypeName_SameName(t *testing.T) {
 	}
 }
 
-func Test_sameTypeName_sameName(t *testing.T) {
+func (s *SameTypeNameSuite) Test_sameName() {
 	tests := []struct {
 		name    string
 		t       *sameTypeName
 		want    int
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t := &sameTypeName{}

--- a/testdata/goldens/two_different_structs_with_same_method_name.go
+++ b/testdata/goldens/two_different_structs_with_same_method_name.go
@@ -1,15 +1,62 @@
 package testdata
 
-import "testing"
+import (
+	"testing"
 
-func TestBook_Open(t *testing.T) {
+	"github.com/stretchr/testify/suite"
+)
+
+type BookSuite struct {
+	suite.Suite
+}
+
+func TestBookSuite(t *testing.T) {
+	suite.Run(t, new(BookSuite))
+}
+
+func (s *BookSuite) SetupTest()    {}
+func (s *BookSuite) TearDownTest() {}
+
+func (s *BookSuite) SetupSuite()    {}
+func (s *BookSuite) TearDownSuite() {}
+
+type DoorSuite struct {
+	suite.Suite
+}
+
+func TestDoorSuite(t *testing.T) {
+	suite.Run(t, new(DoorSuite))
+}
+
+func (s *DoorSuite) SetupTest()    {}
+func (s *DoorSuite) TearDownTest() {}
+
+func (s *DoorSuite) SetupSuite()    {}
+func (s *DoorSuite) TearDownSuite() {}
+
+type XmlSuite struct {
+	suite.Suite
+}
+
+func TestXmlSuite(t *testing.T) {
+	suite.Run(t, new(XmlSuite))
+}
+
+func (s *XmlSuite) SetupTest()    {}
+func (s *XmlSuite) TearDownTest() {}
+
+func (s *XmlSuite) SetupSuite()    {}
+func (s *XmlSuite) TearDownSuite() {}
+
+func (s *BookSuite) TestOpen() {
 	tests := []struct {
 		name    string
 		b       *Book
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		b := &Book{}
 		if err := b.Open(); (err != nil) != tt.wantErr {
@@ -18,14 +65,15 @@ func TestBook_Open(t *testing.T) {
 	}
 }
 
-func Test_door_Open(t *testing.T) {
+func (s *DoorSuite) TestOpen() {
 	tests := []struct {
 		name    string
 		d       *door
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		d := &door{}
 		if err := d.Open(); (err != nil) != tt.wantErr {
@@ -34,14 +82,15 @@ func Test_door_Open(t *testing.T) {
 	}
 }
 
-func Test_xml_Open(t *testing.T) {
+func (s *XmlSuite) TestOpen() {
 	tests := []struct {
 		name    string
 		x       *xml
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		x := &xml{}
 		if err := x.Open(); (err != nil) != tt.wantErr {

--- a/testdata/goldens/two_structs_with_same_method_name.go
+++ b/testdata/goldens/two_structs_with_same_method_name.go
@@ -1,15 +1,48 @@
 package testdata
 
-import "testing"
+import (
+	"testing"
 
-func TestCelsius_String(t *testing.T) {
+	"github.com/stretchr/testify/suite"
+)
+
+type CelsiusSuite struct {
+	suite.Suite
+}
+
+func TestCelsiusSuite(t *testing.T) {
+	suite.Run(t, new(CelsiusSuite))
+}
+
+func (s *CelsiusSuite) SetupTest()    {}
+func (s *CelsiusSuite) TearDownTest() {}
+
+func (s *CelsiusSuite) SetupSuite()    {}
+func (s *CelsiusSuite) TearDownSuite() {}
+
+type FahrenheitSuite struct {
+	suite.Suite
+}
+
+func TestFahrenheitSuite(t *testing.T) {
+	suite.Run(t, new(FahrenheitSuite))
+}
+
+func (s *FahrenheitSuite) SetupTest()    {}
+func (s *FahrenheitSuite) TearDownTest() {}
+
+func (s *FahrenheitSuite) SetupSuite()    {}
+func (s *FahrenheitSuite) TearDownSuite() {}
+
+func (s *CelsiusSuite) TestString() {
 	tests := []struct {
 		name string
 		c    Celsius
 		want string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		if got := tt.c.String(); got != tt.want {
 			t.Errorf("%q. Celsius.String() = %v, want %v", tt.name, got, tt.want)
@@ -17,14 +50,15 @@ func TestCelsius_String(t *testing.T) {
 	}
 }
 
-func TestFahrenheit_String(t *testing.T) {
+func (s *FahrenheitSuite) TestString() {
 	tests := []struct {
 		name string
 		f    Fahrenheit
 		want string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		if got := tt.f.String(); got != tt.want {
 			t.Errorf("%q. Fahrenheit.String() = %v, want %v", tt.name, got, tt.want)

--- a/testdata/goldens/undefined_types.go
+++ b/testdata/goldens/undefined_types.go
@@ -3,9 +3,25 @@ package undefinedtypes
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
 )
 
-func TestUndefined_Do(t *testing.T) {
+type UndefinedSuite struct {
+	suite.Suite
+}
+
+func TestUndefinedSuite(t *testing.T) {
+	suite.Run(t, new(UndefinedSuite))
+}
+
+func (s *UndefinedSuite) SetupTest()    {}
+func (s *UndefinedSuite) TearDownTest() {}
+
+func (s *UndefinedSuite) SetupSuite()    {}
+func (s *UndefinedSuite) TearDownSuite() {}
+
+func (s *UndefinedSuite) TestDo() {
 	type args struct {
 		es Something
 	}
@@ -16,8 +32,9 @@ func TestUndefined_Do(t *testing.T) {
 		want    *Unknown
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		got, err := tt.u.Do(tt.args.es)
 		if (err != nil) != tt.wantErr {

--- a/testdata/goldens/underlying_types.go
+++ b/testdata/goldens/underlying_types.go
@@ -3,16 +3,33 @@ package testdata
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/suite"
 )
 
-func TestCelsius_ToFahrenheit(t *testing.T) {
+type CelsiusSuite struct {
+	suite.Suite
+}
+
+func TestCelsiusSuite(t *testing.T) {
+	suite.Run(t, new(CelsiusSuite))
+}
+
+func (s *CelsiusSuite) SetupTest()    {}
+func (s *CelsiusSuite) TearDownTest() {}
+
+func (s *CelsiusSuite) SetupSuite()    {}
+func (s *CelsiusSuite) TearDownSuite() {}
+
+func (s *CelsiusSuite) TestToFahrenheit() {
 	tests := []struct {
 		name string
 		c    Celsius
 		want Fahrenheit
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
+	t := s.T()
 	for _, tt := range tests {
 		if got := tt.c.ToFahrenheit(); got != tt.want {
 			t.Errorf("%q. Celsius.ToFahrenheit() = %v, want %v", tt.name, got, tt.want)
@@ -29,7 +46,7 @@ func TestHourToSecond(t *testing.T) {
 		args args
 		want time.Duration
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := HourToSecond(tt.args.h); got != tt.want {


### PR DESCRIPTION
This diff restructures the templates to form test suites from any test that are generated against an object which has a receiver e.g. struct methods.

I've found in practice that this is a more useful format as it allows you to setup any necessary mocks in `SetupTest` and subsequently assert those mocks in `TearDownTest`.

This is a decent shift from the existing test generation pattern. Feel free to comment if you disagree with this approach. 