### PR TITLE
use go-cmp instead of reflect.DeepEqual

### DIFF
--- a/gotests_test.go
+++ b/gotests_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"unicode"
 
+	"github.com/google/go-cmp/cmp"
 	"golang.org/x/tools/imports"
 )
 
@@ -643,7 +644,7 @@ func TestGenerateTests(t *testing.T) {
 			continue
 		}
 		if got := string(gts[0].Output); got != tt.want {
-			t.Errorf("%q. GenerateTests(%v) = \n%v, want \n%v", tt.name, tt.args.srcPath, got, tt.want)
+			t.Errorf("%q. GenerateTests(%v) = diff=%v", tt.name, tt.args.srcPath, cmp.Diff(got, tt.want))
 			outputResult(t, tmp, tt.name, gts[0].Output)
 		}
 	}

--- a/internal/render/bindata/esc.go
+++ b/internal/render/bindata/esc.go
@@ -213,7 +213,7 @@ var _escData = map[string]*_escFile{
 		name:    "call.tmpl",
 		local:   "templates/call.tmpl",
 		size:    241,
-		modtime: 1540446832,
+		modtime: 1533199207,
 		compressed: `
 H4sIAAAAAAAC/0SOQWrDQAxFryKMFy0YHaDQA3hTSlvatRjLrsCeFo2SEITuHsY4mdWHP2/el/vEs2SG
 LtG6dhHuF7FfwA9OLGfW2sgM+c8Ax/JpekoWYYbunKf6eicBI1qLb7RxxJO7Ul4Yehmg5xVeXgHfSWlj
@@ -224,22 +224,23 @@ Yy2HvZeIAR5/296PitUbzJB0KU2/K+riTuPX9Z9xLN+kQpOkCMTG7vF85C0AAP//ZQi8iPEAAAA=
 	"/templates/function.tmpl": {
 		name:    "function.tmpl",
 		local:   "templates/function.tmpl",
-		size:    2392,
-		modtime: 1540483824,
+		size:    2541,
+		modtime: 1557758280,
 		compressed: `
-H4sIAAAAAAAC/7RWTW/jNhA9S79i1sgupMJh7g58aJC06KFx4QTNoSgKRh65RGnKJUcJDIL/vSBFfVpO
-c9kcImlIznvz5g0Ta3dYCoWwKGtVkKjUwrnU2mu4KmG1BuZcmvolsJY9o6FHfkDnMoIfCA0JtWfPOdg0
-8UfeBf0NbIsFijfUzqVJCIsS2C/miXRdUAh20Z8Eyp1pYgmdjghliIAJm33euFtztcfJgcTa8O1JBnqn
-I8YlfwTVLn51mG1o8D559ax8mb9xzQ9IqANYoMb1fkRsQOv8RAAMoTN2A8QxvhfUeNH/+HMAo/gBPaxQ
-+3h4RuaWO1e7XuuJXFHa5tEpIk2vWZvyXNAL4n0gWZIEvfyvmTMD3bZoakmmxXnhij6SrIPcItVamQet
-q6jBO1f0oDW8VpWc6OyFvLmB5839ZgU/7nbgtYaCGzQstKGsNFgrSsgqDeypfm2akamKvKCP/B/c5blz
-8NcSiHyTrA3JYynNdptC/GlZdpmcI7atVUbEfEeX4IdqOkYQOcN1L/tcty+M1VkPA83Qn9MRw2aunfsW
-qUeF2e9c1uicbVNcmLbEWtZM/wqIWOMjNpjBZZ+gn71kZiDPPiLezAi1Zb5oQV31o9FareHb64nQsLu6
-LFHbzwDGUWnau1HyNHRTfh7fKAwq5dAxIzwcJSeEhW4cvICrMvi2Xym4lE34EosZGyeijF2bEnMOUOum
-q3Mgt50pM7/vyxqUkLl/ErF2OmKbiYWUZbYY5jqgMXyPsRT0O2ANX9+W0B7/+rZYjuCFOtZd8aj1cgCW
-945ob4nRuIe1yZjoULC1zc1UVIqEqjEWNuewDy11DnnJU0H1nyvqB6fzGHsK12+W3w62NKoOL6zed9Jg
-xLjjRhSDP0xdc6/KOX/5oRxxGOoshcJpoz/N5zvhf9FYSiyI3SMeH/6tucy6DMsxoXzIqOveZ3zYEo5k
-f60liaMckY18eq/+j1Evkrz8D8PEp+ALGl7XLnVp2vr0vwAAAP//X+Qs81gJAAA=
+H4sIAAAAAAAC/7RWwW7jNhA9S18xayQLqfBy71n40MWmRQ/dFEnQPbRFwVhDl6hMueQogUHw3wtSlETJ
+UpDL5hBbQw7fmzfzKFtboZAKYSNatSfZqI1zubUf4ErAzQ6Yc3nul8Ba9oiGvvIjOlcQ/EBoSKoDeyzB
+5plPeZH0D7B73KN8Ru1cnoWwFMB+MQ+k2z2F4BD9SWJdmS6W0fmEIEIETNjsz427NVcHnCVk1oZnTzLQ
+O58wLvkUVFV8GjD7UPJ99tWz8mX+xjU/IqEOYIEa14cJsYTWZUYADKELdgniFN8Larzof/yVwCh+RA8r
+1SEmL8jcc+eqGrWeyRWl7T4GRWozatYfeSnoinivSJZlQS//byEn0e0eTVuT6XG+cUWvSTZA3iO1Wplb
+rZuowQtXdKs1PDVNPdPZC/nxIzzefbm7gR+rCrzWsOcGDQttEI0Ga6WAotHAHtqnrhmFasgL+pX/i1VZ
+Ogd/b4HIN8nacHgspdtuc4h/PcvhJOeI3beqIGK+o1vwpprbCCJn+DDKvtTtFVtd9DDQDP05nzBs5tq5
+95F6VJj9zusWnbP9EStuy6xlnftvgIh1c8QSD27HA0bvZQuGvHiIeAsW6sv8piUN1U+sdbOD909nQsM+
+t0Kgtm8BjFbp2nun6nM6TeVl/E5hUKmEgRnh8VRzQtjoboI3cCXC3I4re17XXXiNxcIYZ1LErs2JOQeo
+ddfVJZBPw1AWft+7HShZl/6TiPXuiG0mFo4UxSY964jG8APGUtDvgB1cP2+hT79+3mwn8FKd2qF41Hqb
+gJXjRPS3xMTuYW1mEx0Ktra7mfaNIqlajIUtTdirI3UJuTZTQfWfGxqNM8wYewjXb1F+SrZ0qqYX1jh3
+tcGI8ZkbuU9eTENzr8TSfHlTTjikOtdS4bzRb+bznfDf7Y8ndvtfy+tiyNxOiZQpk6Frb5m/nmgk+Wtb
+kzzVE5KRxzijcP1srRc/eLgAf533rZ40xN/mf6pKCrELKf7ade614V4rMNSTXPpvQd6CF+6LFGJdt4FU
+uf4rZmYe8Gqn7xCXuzzvzfN/AAAA//9kJyCm7QkAAA==
 `,
 	},
 
@@ -247,7 +248,7 @@ f60liaMckY18eq/+j1Evkrz8D8PEp+ALGl7XLnVp2vr0vwAAAP//X+Qs81gJAAA=
 		name:    "header.tmpl",
 		local:   "templates/header.tmpl",
 		size:    142,
-		modtime: 1540481163,
+		modtime: 1533199207,
 		compressed: `
 H4sIAAAAAAAC/0TMMQ7CMAyF4d2nsDrBQC7BxIK4gkUebYXiViGb9e6OlAi6/bL1voiM1+rQaYFl1ImU
 iGo+Q9N1KwXePmRE6g941gspuz3fNkMj0mMkKbKWfatNT4dw65cB3K2AHJO2/DhSzv/6BgAA///GzMM9
@@ -259,7 +260,7 @@ jgAAAA==
 		name:    "inline.tmpl",
 		local:   "templates/inline.tmpl",
 		size:    49,
-		modtime: 1540446006,
+		modtime: 1533199207,
 		compressed: `
 H4sIAAAAAAAC/6quTklNy8xLVVDKzMvJzEtVqq1VqK4uSc0tyEksSVVQSk7MyVFS0AOLpual1NYCAgAA
 //+q60H/MQAAAA==
@@ -270,7 +271,7 @@ H4sIAAAAAAAC/6quTklNy8xLVVDKzMvJzEtVqq1VqK4uSc0tyEksSVVQSk7MyVFS0AOLpual1NYCAgAA
 		name:    "inputs.tmpl",
 		local:   "templates/inputs.tmpl",
 		size:    152,
-		modtime: 1540446821,
+		modtime: 1533199207,
 		compressed: `
 H4sIAAAAAAAC/0yNMQoCQQxFrxKWLSUHEDyAneAJIptZptgomWz1yd1lRoupEh7/vw9sWqopLdU+Z7Ql
 E1gLXW/E/a2F7B3Ez/MV2qJlRrDJoRcC1LZ/Zi388GpxH5IOXWzXwcXl0FD/dcX3xsCgfWLyzOcbAAD/
@@ -282,7 +283,7 @@ E1gLXW/E/a2F7B3Ez/MV2qJlRrDJoRcC1LZ/Zi388GpxH5IOXWzXwcXl0FD/dcX3xsCgfWLyzOcbAAD/
 		name:    "message.tmpl",
 		local:   "templates/message.tmpl",
 		size:    201,
-		modtime: 1540446006,
+		modtime: 1533199207,
 		compressed: `
 H4sIAAAAAAAC/zyN4WqDQBCE//sUiyi0oPsAhT5A/xRpS/9f4mgW9GLuTkNY9t2DB/HXDDPDN6o9BvGg
 ckaMbkRJrVmhKgP5ayL+XU8JMUWz+sakCt+bqd4lXYh/cIZsCHvCf48F/O+mFWZ8DPnbzTB7y0Tugvj0
@@ -294,7 +295,7 @@ ckaMbkRJrVmhKgP5ayL+XU8JMUWz+sakCt+bqd4lXYh/cIZsCHvCf48F/O+mFWZ8DPnbzTB7y0Tugvj0
 		name:    "results.tmpl",
 		local:   "templates/results.tmpl",
 		size:    168,
-		modtime: 1540446006,
+		modtime: 1533199207,
 		compressed: `
 H4sIAAAAAAAC/1yNTQrCQAyFr/Iosyw9gOBS3HsDoRkJlAy8ma5C7i6pRcFVfr4vee6rVDXBROn7NvoU
 AXc+7SUoOqPIhssVy+ODI9y1omjEDHexNTf3NrBkc85a82DstH4jG1MW8uQ4hMbv0385A3/uUd8BAAD/

--- a/internal/render/templates/function.tmpl
+++ b/internal/render/templates/function.tmpl
@@ -74,9 +74,10 @@ func {{.TestName}}(t *testing.T) {
 				{{- else if .IsBasicType}}
 					if {{if $f.OnlyReturnsOneValue}}{{Got .}} := {{template "inline" $f}}; {{end}} {{Got .}} != tt.{{Want .}} {
 				{{- else}}
-					if {{if $f.OnlyReturnsOneValue}}{{Got .}} := {{template "inline" $f}}; {{end}} !reflect.DeepEqual({{Got .}}, tt.{{Want .}}) {
+					if {{if $f.OnlyReturnsOneValue}}{{Got .}} := {{template "inline" $f}}; {{end}} !cmp.Equal({{Got .}}, tt.{{Want .}}) {
 				{{- end}}
-				t.Errorf("{{template "message" $f}} {{if $f.ReturnsMultiple}}{{Got .}} {{end}}= %v, want %v", {{template "inputs" $f}} {{Got .}}, tt.{{Want .}})
+				t.Errorf("{{template "message" $f}} {{if $f.ReturnsMultiple}}{{Got .}} {{end}}= %v, want %v{{ if (not ( or .IsWriter .IsBasicType))}}\ndiff=%v{{ end }}", {{template "inputs" $f}} {{Got .}}, tt.{{Want .}}
+				    {{- if (not ( or .IsWriter .IsBasicType))}}, cmp.Diff({{Got .}}, tt.{{Want .}}){{ end }})
 				}
 			{{- end}}
 		{{- if .Subtests }} }) {{- end -}}

--- a/testdata/goldens/custom_importer_fails.go
+++ b/testdata/goldens/custom_importer_fails.go
@@ -1,8 +1,9 @@
 package testdata
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFooFilter(t *testing.T) {
@@ -15,7 +16,7 @@ func TestFooFilter(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := FooFilter(tt.args.strs)
@@ -23,8 +24,8 @@ func TestFooFilter(t *testing.T) {
 			t.Errorf("%q. FooFilter() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			continue
 		}
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. FooFilter() = %v, want %v", tt.name, got, tt.want)
+		if !cmp.Equal(got, tt.want) {
+			t.Errorf("%q. FooFilter() = %v, want %v\ndiff=%v", tt.name, got, tt.want, cmp.Diff(got, tt.want))
 		}
 	}
 }
@@ -39,7 +40,7 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		b := &Bar{}
@@ -58,7 +59,7 @@ func Test_bazFilter(t *testing.T) {
 		args args
 		want float64
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := bazFilter(tt.args.f); got != tt.want {

--- a/testdata/goldens/existing_test_file.go
+++ b/testdata/goldens/existing_test_file.go
@@ -1,8 +1,9 @@
 package testdata
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestBarBar100(t *testing.T) {
@@ -55,7 +56,7 @@ func TestFoo100(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := Foo100(tt.args.strs)
@@ -63,8 +64,8 @@ func TestFoo100(t *testing.T) {
 			t.Errorf("%q. Foo100() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			continue
 		}
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. Foo100() = %v, want %v", tt.name, got, tt.want)
+		if !cmp.Equal(got, tt.want) {
+			t.Errorf("%q. Foo100() = %v, want %v\ndiff=%v", tt.name, got, tt.want, cmp.Diff(got, tt.want))
 		}
 	}
 }
@@ -79,7 +80,7 @@ func TestBar_Bar100(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		b := &Bar{}
@@ -98,7 +99,7 @@ func Test_baz100(t *testing.T) {
 		args args
 		want float64
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := baz100(tt.args.f); got != tt.want {

--- a/testdata/goldens/function_returning_two_results_and_an_error.go
+++ b/testdata/goldens/function_returning_two_results_and_an_error.go
@@ -1,8 +1,9 @@
 package testdata
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFoo25(t *testing.T) {
@@ -16,7 +17,7 @@ func TestFoo25(t *testing.T) {
 		want1   []byte
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, got1, err := Foo25(tt.args.in0)
@@ -27,8 +28,8 @@ func TestFoo25(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("%q. Foo25() got = %v, want %v", tt.name, got, tt.want)
 		}
-		if !reflect.DeepEqual(got1, tt.want1) {
-			t.Errorf("%q. Foo25() got1 = %v, want %v", tt.name, got1, tt.want1)
+		if !cmp.Equal(got1, tt.want1) {
+			t.Errorf("%q. Foo25() got1 = %v, want %v\ndiff=%v", tt.name, got1, tt.want1, cmp.Diff(got1, tt.want1))
 		}
 	}
 }

--- a/testdata/goldens/function_with_channel_parameter_and_result.go
+++ b/testdata/goldens/function_with_channel_parameter_and_result.go
@@ -1,8 +1,9 @@
 package testdata
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFoo23(t *testing.T) {
@@ -14,11 +15,11 @@ func TestFoo23(t *testing.T) {
 		args args
 		want chan string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
-		if got := Foo23(tt.args.ch); !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. Foo23() = %v, want %v", tt.name, got, tt.want)
+		if got := Foo23(tt.args.ch); !cmp.Equal(got, tt.want) {
+			t.Errorf("%q. Foo23() = %v, want %v\ndiff=%v", tt.name, got, tt.want, cmp.Diff(got, tt.want))
 		}
 	}
 }

--- a/testdata/goldens/function_with_defined_interface_type_parameter_and_result.go
+++ b/testdata/goldens/function_with_defined_interface_type_parameter_and_result.go
@@ -1,8 +1,9 @@
 package testdata
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFoo16(t *testing.T) {
@@ -14,11 +15,11 @@ func TestFoo16(t *testing.T) {
 		args args
 		want Bazzar
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
-		if got := Foo16(tt.args.in); !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. Foo16() = %v, want %v", tt.name, got, tt.want)
+		if got := Foo16(tt.args.in); !cmp.Equal(got, tt.want) {
+			t.Errorf("%q. Foo16() = %v, want %v\ndiff=%v", tt.name, got, tt.want, cmp.Diff(got, tt.want))
 		}
 	}
 }

--- a/testdata/goldens/function_with_imported_interface_receiver_parameter_and_result.go
+++ b/testdata/goldens/function_with_imported_interface_receiver_parameter_and_result.go
@@ -2,8 +2,9 @@ package testdata
 
 import (
 	"io"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFoo17(t *testing.T) {
@@ -15,11 +16,11 @@ func TestFoo17(t *testing.T) {
 		args args
 		want io.Reader
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
-		if got := Foo17(tt.args.r); !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. Foo17() = %v, want %v", tt.name, got, tt.want)
+		if got := Foo17(tt.args.r); !cmp.Equal(got, tt.want) {
+			t.Errorf("%q. Foo17() = %v, want %v\ndiff=%v", tt.name, got, tt.want, cmp.Diff(got, tt.want))
 		}
 	}
 }

--- a/testdata/goldens/function_with_imported_struct_receiver_parameter_and_result.go
+++ b/testdata/goldens/function_with_imported_struct_receiver_parameter_and_result.go
@@ -2,8 +2,9 @@ package testdata
 
 import (
 	"os"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFoo18(t *testing.T) {
@@ -15,11 +16,11 @@ func TestFoo18(t *testing.T) {
 		args args
 		want *os.File
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
-		if got := Foo18(tt.args.t); !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. Foo18() = %v, want %v", tt.name, got, tt.want)
+		if got := Foo18(tt.args.t); !cmp.Equal(got, tt.want) {
+			t.Errorf("%q. Foo18() = %v, want %v\ndiff=%v", tt.name, got, tt.want, cmp.Diff(got, tt.want))
 		}
 	}
 }

--- a/testdata/goldens/function_with_interface_parameter_and_result.go
+++ b/testdata/goldens/function_with_interface_parameter_and_result.go
@@ -1,8 +1,9 @@
 package testdata
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFoo21(t *testing.T) {
@@ -14,11 +15,11 @@ func TestFoo21(t *testing.T) {
 		args args
 		want interface{}
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
-		if got := Foo21(tt.args.i); !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. Foo21() = %v, want %v", tt.name, got, tt.want)
+		if got := Foo21(tt.args.i); !cmp.Equal(got, tt.want) {
+			t.Errorf("%q. Foo21() = %v, want %v\ndiff=%v", tt.name, got, tt.want, cmp.Diff(got, tt.want))
 		}
 	}
 }

--- a/testdata/goldens/function_with_map_argument_and_return_type.go
+++ b/testdata/goldens/function_with_map_argument_and_return_type.go
@@ -1,8 +1,9 @@
 package testdata
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFoo10(t *testing.T) {
@@ -14,11 +15,11 @@ func TestFoo10(t *testing.T) {
 		args args
 		want map[string]*Bar
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
-		if got := Foo10(tt.args.m); !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. Foo10() = %v, want %v", tt.name, got, tt.want)
+		if got := Foo10(tt.args.m); !cmp.Equal(got, tt.want) {
+			t.Errorf("%q. Foo10() = %v, want %v\ndiff=%v", tt.name, got, tt.want, cmp.Diff(got, tt.want))
 		}
 	}
 }

--- a/testdata/goldens/function_with_named_imports.go
+++ b/testdata/goldens/function_with_named_imports.go
@@ -2,8 +2,9 @@ package testdata
 
 import (
 	ht "html/template"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFoo22(t *testing.T) {
@@ -15,11 +16,11 @@ func TestFoo22(t *testing.T) {
 		args args
 		want *ht.Template
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
-		if got := Foo22(tt.args.t); !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. Foo22() = %v, want %v", tt.name, got, tt.want)
+		if got := Foo22(tt.args.t); !cmp.Equal(got, tt.want) {
+			t.Errorf("%q. Foo22() = %v, want %v\ndiff=%v", tt.name, got, tt.want, cmp.Diff(got, tt.want))
 		}
 	}
 }

--- a/testdata/goldens/function_with_slice_argument_and_return_type.go
+++ b/testdata/goldens/function_with_slice_argument_and_return_type.go
@@ -1,8 +1,9 @@
 package testdata
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFoo11(t *testing.T) {
@@ -15,7 +16,7 @@ func TestFoo11(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := Foo11(tt.args.strs)
@@ -23,8 +24,8 @@ func TestFoo11(t *testing.T) {
 			t.Errorf("%q. Foo11() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			continue
 		}
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. Foo11() = %v, want %v", tt.name, got, tt.want)
+		if !cmp.Equal(got, tt.want) {
+			t.Errorf("%q. Foo11() = %v, want %v\ndiff=%v", tt.name, got, tt.want, cmp.Diff(got, tt.want))
 		}
 	}
 }

--- a/testdata/goldens/function_with_struct_pointer_argument_and_return_type.go
+++ b/testdata/goldens/function_with_struct_pointer_argument_and_return_type.go
@@ -1,8 +1,9 @@
 package testdata
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFoo8(t *testing.T) {
@@ -15,7 +16,7 @@ func TestFoo8(t *testing.T) {
 		want    *Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := Foo8(tt.args.b)
@@ -23,8 +24,8 @@ func TestFoo8(t *testing.T) {
 			t.Errorf("%q. Foo8() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			continue
 		}
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. Foo8() = %v, want %v", tt.name, got, tt.want)
+		if !cmp.Equal(got, tt.want) {
+			t.Errorf("%q. Foo8() = %v, want %v\ndiff=%v", tt.name, got, tt.want, cmp.Diff(got, tt.want))
 		}
 	}
 }

--- a/testdata/goldens/multiple_functions.go
+++ b/testdata/goldens/multiple_functions.go
@@ -1,8 +1,9 @@
 package testdata
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFooFilter(t *testing.T) {
@@ -15,7 +16,7 @@ func TestFooFilter(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := FooFilter(tt.args.strs)
@@ -23,8 +24,8 @@ func TestFooFilter(t *testing.T) {
 			t.Errorf("%q. FooFilter() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			continue
 		}
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. FooFilter() = %v, want %v", tt.name, got, tt.want)
+		if !cmp.Equal(got, tt.want) {
+			t.Errorf("%q. FooFilter() = %v, want %v\ndiff=%v", tt.name, got, tt.want, cmp.Diff(got, tt.want))
 		}
 	}
 }
@@ -39,7 +40,7 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		b := &Bar{}
@@ -58,7 +59,7 @@ func Test_bazFilter(t *testing.T) {
 		args args
 		want float64
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := bazFilter(tt.args.f); got != tt.want {

--- a/testdata/goldens/multiple_functions_excluding_on_method.go
+++ b/testdata/goldens/multiple_functions_excluding_on_method.go
@@ -1,8 +1,9 @@
 package testdata
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFooFilter(t *testing.T) {
@@ -15,7 +16,7 @@ func TestFooFilter(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := FooFilter(tt.args.strs)
@@ -23,8 +24,8 @@ func TestFooFilter(t *testing.T) {
 			t.Errorf("%q. FooFilter() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			continue
 		}
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. FooFilter() = %v, want %v", tt.name, got, tt.want)
+		if !cmp.Equal(got, tt.want) {
+			t.Errorf("%q. FooFilter() = %v, want %v\ndiff=%v", tt.name, got, tt.want, cmp.Diff(got, tt.want))
 		}
 	}
 }
@@ -38,7 +39,7 @@ func Test_bazFilter(t *testing.T) {
 		args args
 		want float64
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := bazFilter(tt.args.f); got != tt.want {

--- a/testdata/goldens/multiple_functions_excluding_on_receiver.go
+++ b/testdata/goldens/multiple_functions_excluding_on_receiver.go
@@ -1,8 +1,9 @@
 package testdata
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFooFilter(t *testing.T) {
@@ -15,7 +16,7 @@ func TestFooFilter(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := FooFilter(tt.args.strs)
@@ -23,8 +24,8 @@ func TestFooFilter(t *testing.T) {
 			t.Errorf("%q. FooFilter() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			continue
 		}
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. FooFilter() = %v, want %v", tt.name, got, tt.want)
+		if !cmp.Equal(got, tt.want) {
+			t.Errorf("%q. FooFilter() = %v, want %v\ndiff=%v", tt.name, got, tt.want, cmp.Diff(got, tt.want))
 		}
 	}
 }
@@ -38,7 +39,7 @@ func Test_bazFilter(t *testing.T) {
 		args args
 		want float64
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := bazFilter(tt.args.f); got != tt.want {

--- a/testdata/goldens/multiple_functions_filtering_exported.go
+++ b/testdata/goldens/multiple_functions_filtering_exported.go
@@ -1,8 +1,9 @@
 package testdata
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFooFilter(t *testing.T) {
@@ -15,7 +16,7 @@ func TestFooFilter(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := FooFilter(tt.args.strs)
@@ -23,8 +24,8 @@ func TestFooFilter(t *testing.T) {
 			t.Errorf("%q. FooFilter() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			continue
 		}
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. FooFilter() = %v, want %v", tt.name, got, tt.want)
+		if !cmp.Equal(got, tt.want) {
+			t.Errorf("%q. FooFilter() = %v, want %v\ndiff=%v", tt.name, got, tt.want, cmp.Diff(got, tt.want))
 		}
 	}
 }
@@ -39,7 +40,7 @@ func TestBar_BarFilter(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		b := &Bar{}

--- a/testdata/goldens/multiple_functions_filtering_exported_with_only.go
+++ b/testdata/goldens/multiple_functions_filtering_exported_with_only.go
@@ -1,8 +1,9 @@
 package testdata
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFooFilter(t *testing.T) {
@@ -15,7 +16,7 @@ func TestFooFilter(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := FooFilter(tt.args.strs)
@@ -23,8 +24,8 @@ func TestFooFilter(t *testing.T) {
 			t.Errorf("%q. FooFilter() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			continue
 		}
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. FooFilter() = %v, want %v", tt.name, got, tt.want)
+		if !cmp.Equal(got, tt.want) {
+			t.Errorf("%q. FooFilter() = %v, want %v\ndiff=%v", tt.name, got, tt.want, cmp.Diff(got, tt.want))
 		}
 	}
 }

--- a/testdata/goldens/multiple_functions_with_case-insensitive_only.go
+++ b/testdata/goldens/multiple_functions_with_case-insensitive_only.go
@@ -1,8 +1,9 @@
 package testdata
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFooFilter(t *testing.T) {
@@ -15,7 +16,7 @@ func TestFooFilter(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := FooFilter(tt.args.strs)
@@ -23,8 +24,8 @@ func TestFooFilter(t *testing.T) {
 			t.Errorf("%q. FooFilter() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			continue
 		}
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. FooFilter() = %v, want %v", tt.name, got, tt.want)
+		if !cmp.Equal(got, tt.want) {
+			t.Errorf("%q. FooFilter() = %v, want %v\ndiff=%v", tt.name, got, tt.want, cmp.Diff(got, tt.want))
 		}
 	}
 }
@@ -38,7 +39,7 @@ func Test_bazFilter(t *testing.T) {
 		args args
 		want float64
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := bazFilter(tt.args.f); got != tt.want {

--- a/testdata/goldens/multiple_functions_with_only.go
+++ b/testdata/goldens/multiple_functions_with_only.go
@@ -1,8 +1,9 @@
 package testdata
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFooFilter(t *testing.T) {
@@ -15,7 +16,7 @@ func TestFooFilter(t *testing.T) {
 		want    []*Bar
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := FooFilter(tt.args.strs)
@@ -23,8 +24,8 @@ func TestFooFilter(t *testing.T) {
 			t.Errorf("%q. FooFilter() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			continue
 		}
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. FooFilter() = %v, want %v", tt.name, got, tt.want)
+		if !cmp.Equal(got, tt.want) {
+			t.Errorf("%q. FooFilter() = %v, want %v\ndiff=%v", tt.name, got, tt.want, cmp.Diff(got, tt.want))
 		}
 	}
 }
@@ -38,7 +39,7 @@ func Test_bazFilter(t *testing.T) {
 		args args
 		want float64
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		if got := bazFilter(tt.args.f); got != tt.want {

--- a/testdata/goldens/multiple_named_results.go
+++ b/testdata/goldens/multiple_named_results.go
@@ -1,8 +1,9 @@
 package testdata
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFoo26(t *testing.T) {
@@ -17,7 +18,7 @@ func TestFoo26(t *testing.T) {
 		want2   []byte
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, gotI, got2, err := Foo26(tt.args.v)
@@ -31,8 +32,8 @@ func TestFoo26(t *testing.T) {
 		if gotI != tt.wantI {
 			t.Errorf("%q. Foo26() gotI = %v, want %v", tt.name, gotI, tt.wantI)
 		}
-		if !reflect.DeepEqual(got2, tt.want2) {
-			t.Errorf("%q. Foo26() got2 = %v, want %v", tt.name, got2, tt.want2)
+		if !cmp.Equal(got2, tt.want2) {
+			t.Errorf("%q. Foo26() got2 = %v, want %v\ndiff=%v", tt.name, got2, tt.want2, cmp.Diff(got2, tt.want2))
 		}
 	}
 }

--- a/testdata/goldens/receiver_is_indirect_imported_struct.go
+++ b/testdata/goldens/receiver_is_indirect_imported_struct.go
@@ -7,7 +7,7 @@ func Test_someIndirectImportedStruct_Foo037(t *testing.T) {
 		name string
 		smtg *someIndirectImportedStruct
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		smtg := &someIndirectImportedStruct{}

--- a/testdata/goldens/receiver_struct_with_fields_with_complex_package_names.go
+++ b/testdata/goldens/receiver_struct_with_fields_with_complex_package_names.go
@@ -2,8 +2,9 @@ package testdata
 
 import (
 	"go/types"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestImporter_Foo35(t *testing.T) {
@@ -20,15 +21,15 @@ func TestImporter_Foo35(t *testing.T) {
 		args   args
 		want   *types.Var
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		i := &Importer{
 			Importer: tt.fields.Importer,
 			Field:    tt.fields.Field,
 		}
-		if got := i.Foo35(tt.args.t); !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. Importer.Foo35() = %v, want %v", tt.name, got, tt.want)
+		if got := i.Foo35(tt.args.t); !cmp.Equal(got, tt.want) {
+			t.Errorf("%q. Importer.Foo35() = %v, want %v\ndiff=%v", tt.name, got, tt.want, cmp.Diff(got, tt.want))
 		}
 	}
 }

--- a/testdata/goldens/struct_value_method_with_struct_value_return_type.go
+++ b/testdata/goldens/struct_value_method_with_struct_value_return_type.go
@@ -1,8 +1,9 @@
 package testdata
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestBar_Foo9(t *testing.T) {
@@ -11,12 +12,12 @@ func TestBar_Foo9(t *testing.T) {
 		b    Bar
 		want Bar
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		b := Bar{}
-		if got := b.Foo9(); !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. Bar.Foo9() = %v, want %v", tt.name, got, tt.want)
+		if got := b.Foo9(); !cmp.Equal(got, tt.want) {
+			t.Errorf("%q. Bar.Foo9() = %v, want %v\ndiff=%v", tt.name, got, tt.want, cmp.Diff(got, tt.want))
 		}
 	}
 }

--- a/testdata/goldens/target_test_file.go
+++ b/testdata/goldens/target_test_file.go
@@ -2,8 +2,9 @@ package testdata
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestBarBar100(t *testing.T) {
@@ -67,8 +68,8 @@ func Test_wrapToString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := wrapToString(tt.args.in); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("wrapToString() = %v, want %v", got, tt.want)
+			if got := wrapToString(tt.args.in); !cmp.Equal(got, tt.want) {
+				t.Errorf("wrapToString() = %v, want %v\ndiff=%v", got, tt.want, cmp.Diff(got, tt.want))
 			}
 		})
 	}

--- a/testdata/goldens/undefined_types.go
+++ b/testdata/goldens/undefined_types.go
@@ -1,8 +1,9 @@
 package undefinedtypes
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestUndefined_Do(t *testing.T) {
@@ -16,7 +17,7 @@ func TestUndefined_Do(t *testing.T) {
 		want    *Unknown
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		got, err := tt.u.Do(tt.args.es)
@@ -24,8 +25,8 @@ func TestUndefined_Do(t *testing.T) {
 			t.Errorf("%q. Undefined.Do() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			continue
 		}
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. Undefined.Do() = %v, want %v", tt.name, got, tt.want)
+		if !cmp.Equal(got, tt.want) {
+			t.Errorf("%q. Undefined.Do() = %v, want %v\ndiff=%v", tt.name, got, tt.want, cmp.Diff(got, tt.want))
 		}
 	}
 }


### PR DESCRIPTION
https://github.com/cweill/gotests/issues/98

https://github.com/google/go-cmp/ is more usefull then reflect.DeepEqual

I changed reflect.DeepEqual to cmp.Equal
and add to t.Errorf cmp.Diff for more detailed view of diff between got and want
for exmaple how it looks like

```
=== RUN   TestAddress2addressResultSlice/two_diff_addr
    --- FAIL: TestAddress2addressResultSlice/two_diff_addr (0.00s)
        helpers_test.go:161: Address2addressResultSlice() = [address:<UID:"ololo1" >  address:<UID:"trololo" > ], want [address:<UID:"ololo" >  address:<UID:"trololo" > ]
             diff =   []*address_api.AddressResult{
              	&{
              		Precision:            s"other",
            - 		Address:              s`UID:"ololo1" `,
            + 		Address:              s`UID:"ololo" `,
              		Distance:             0,
              		... // 2 identical fields
              	},
              	&{Address: s`UID:"trololo" `},
              }
FAIL
```