### PR TITLE
Add alias for `t` receiver type name

### DIFF
--- a/gotests_test.go
+++ b/gotests_test.go
@@ -529,6 +529,15 @@ func TestGenerateTests(t *testing.T) {
 			want: mustReadAndFormatGoFile(t, "testdata/goldens/subtest_edition_-_functions_and_receivers_with_same_names_except_exporting.go"),
 		},
 		{
+			name: "Test t method receiver",
+			args: args{
+				srcPath: `testdata/test_t_receiver.go`,
+			},
+			wantNoTests: false,
+			wantErr:     false,
+			want:        mustReadAndFormatGoFile(t, `testdata/goldens/test_t_receiver.go`),
+		},
+		{
 			name: "Init function",
 			args: args{
 				srcPath: `testdata/init_func.go`,

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -76,6 +76,10 @@ func receiverName(f *models.Receiver) string {
 	if n == "name" {
 		// Avoid conflict with test struct's "name" field.
 		n = "n"
+	} else if n == "t" {
+		// Avoid conflict with test argument.
+		// "tr" is short for t receiver.
+		n = "tr"
 	}
 	return n
 }

--- a/testdata/goldens/functions_and_receivers_with_same_names_except_exporting.go
+++ b/testdata/goldens/functions_and_receivers_with_same_names_except_exporting.go
@@ -45,15 +45,15 @@ func Test_sameName(t *testing.T) {
 func TestSameTypeName_SameName(t *testing.T) {
 	tests := []struct {
 		name    string
-		t       *SameTypeName
+		tr      *SameTypeName
 		want    int
 		wantErr bool
 	}{
 	// TODO: Add test cases.
 	}
 	for _, tt := range tests {
-		t := &SameTypeName{}
-		got, err := t.SameName()
+		tr := &SameTypeName{}
+		got, err := tr.SameName()
 		if (err != nil) != tt.wantErr {
 			t.Errorf("%q. SameTypeName.SameName() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			continue
@@ -67,15 +67,15 @@ func TestSameTypeName_SameName(t *testing.T) {
 func TestSameTypeName_sameName(t *testing.T) {
 	tests := []struct {
 		name    string
-		t       *SameTypeName
+		tr      *SameTypeName
 		want    int
 		wantErr bool
 	}{
 	// TODO: Add test cases.
 	}
 	for _, tt := range tests {
-		t := &SameTypeName{}
-		got, err := t.sameName()
+		tr := &SameTypeName{}
+		got, err := tr.sameName()
 		if (err != nil) != tt.wantErr {
 			t.Errorf("%q. SameTypeName.sameName() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			continue
@@ -89,15 +89,15 @@ func TestSameTypeName_sameName(t *testing.T) {
 func Test_sameTypeName_SameName(t *testing.T) {
 	tests := []struct {
 		name    string
-		t       *sameTypeName
+		tr      *sameTypeName
 		want    int
 		wantErr bool
 	}{
 	// TODO: Add test cases.
 	}
 	for _, tt := range tests {
-		t := &sameTypeName{}
-		got, err := t.SameName()
+		tr := &sameTypeName{}
+		got, err := tr.SameName()
 		if (err != nil) != tt.wantErr {
 			t.Errorf("%q. sameTypeName.SameName() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			continue
@@ -111,15 +111,15 @@ func Test_sameTypeName_SameName(t *testing.T) {
 func Test_sameTypeName_sameName(t *testing.T) {
 	tests := []struct {
 		name    string
-		t       *sameTypeName
+		tr      *sameTypeName
 		want    int
 		wantErr bool
 	}{
 	// TODO: Add test cases.
 	}
 	for _, tt := range tests {
-		t := &sameTypeName{}
-		got, err := t.sameName()
+		tr := &sameTypeName{}
+		got, err := tr.sameName()
 		if (err != nil) != tt.wantErr {
 			t.Errorf("%q. sameTypeName.sameName() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			continue

--- a/testdata/goldens/subtest_edition_-_functions_and_receivers_with_same_names_except_exporting.go
+++ b/testdata/goldens/subtest_edition_-_functions_and_receivers_with_same_names_except_exporting.go
@@ -49,7 +49,7 @@ func Test_sameName(t *testing.T) {
 func TestSameTypeName_SameName(t *testing.T) {
 	tests := []struct {
 		name    string
-		t       *SameTypeName
+		tr      *SameTypeName
 		want    int
 		wantErr bool
 	}{
@@ -57,8 +57,8 @@ func TestSameTypeName_SameName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t := &SameTypeName{}
-			got, err := t.SameName()
+			tr := &SameTypeName{}
+			got, err := tr.SameName()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SameTypeName.SameName() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -73,7 +73,7 @@ func TestSameTypeName_SameName(t *testing.T) {
 func TestSameTypeName_sameName(t *testing.T) {
 	tests := []struct {
 		name    string
-		t       *SameTypeName
+		tr      *SameTypeName
 		want    int
 		wantErr bool
 	}{
@@ -81,8 +81,8 @@ func TestSameTypeName_sameName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t := &SameTypeName{}
-			got, err := t.sameName()
+			tr := &SameTypeName{}
+			got, err := tr.sameName()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SameTypeName.sameName() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -97,7 +97,7 @@ func TestSameTypeName_sameName(t *testing.T) {
 func Test_sameTypeName_SameName(t *testing.T) {
 	tests := []struct {
 		name    string
-		t       *sameTypeName
+		tr      *sameTypeName
 		want    int
 		wantErr bool
 	}{
@@ -105,8 +105,8 @@ func Test_sameTypeName_SameName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t := &sameTypeName{}
-			got, err := t.SameName()
+			tr := &sameTypeName{}
+			got, err := tr.SameName()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("sameTypeName.SameName() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -121,7 +121,7 @@ func Test_sameTypeName_SameName(t *testing.T) {
 func Test_sameTypeName_sameName(t *testing.T) {
 	tests := []struct {
 		name    string
-		t       *sameTypeName
+		tr      *sameTypeName
 		want    int
 		wantErr bool
 	}{
@@ -129,8 +129,8 @@ func Test_sameTypeName_sameName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t := &sameTypeName{}
-			got, err := t.sameName()
+			tr := &sameTypeName{}
+			got, err := tr.sameName()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("sameTypeName.sameName() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/testdata/goldens/test_t_receiver.go
+++ b/testdata/goldens/test_t_receiver.go
@@ -1,0 +1,19 @@
+package testdata
+
+import "testing"
+
+func TestTestReceiver_FooMethod(t *testing.T) {
+	tests := []struct {
+		name    string
+		tr      *TestReceiver
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		tr := &TestReceiver{}
+		if err := tr.FooMethod(); (err != nil) != tt.wantErr {
+			t.Errorf("%q. TestReceiver.FooMethod() error = %v, wantErr %v", tt.name, err, tt.wantErr)
+		}
+	}
+}

--- a/testdata/test_t_receiver.go
+++ b/testdata/test_t_receiver.go
@@ -1,0 +1,7 @@
+package testdata
+
+type TestReceiver struct{}
+
+func (t *TestReceiver) FooMethod() error {
+	return nil
+}


### PR DESCRIPTION
Create alias `tr` for receiver with name `t` to avoid conflict with the test
parameters (`t *testing.T`).
Also, add unit test for method with `t` receiver type name and fixes conflict
unit tests accordingly.

```diff
func TestTestReceiver_FooMethod(t *testing.T) {
	tests := []struct {
		name    string
-		t       *TestReceiver
+		tr      *TestReceiver
		wantErr bool
	}{
		// TODO: Add test cases.
	}
	for _, tt := range tests {
-		t := &TestReceiver{}
-		if err := t.FooMethod(); (err != nil) != tt.wantErr {
+		tr := &TestReceiver{}
+		if err := tr.FooMethod(); (err != nil) != tt.wantErr {
	...
```

fix [#100](https://github.com/cweill/gotests/issues/100)