### PR TITLE
Implement GitHub Actions support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,6 +34,7 @@ jobs:
         echo Workspace: ${{ github.workspace }}
         go get github.com/mattn/goveralls
         go get golang.org/x/tools/cmd/cover
+        golang.org/x/mod/module
       env:
         GOPATH: ${{ github.workspace }}/go
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,12 +29,9 @@ jobs:
       run: |
         go get github.com/mattn/goveralls
         go get golang.org/x/tools/cmd/cover
-        
-    - name: Build
-      run: go build -v ./...
 
     - name: Test
-      run: go test -v ./...
+      run: go test ./...
       
     - name: Coverage
       run: go test -c -covermode=count -coverpkg=github.com/cweill/gotests,github.com/cweill/gotests/internal/input,github.com/cweill/gotests/internal/render,github.com/cweill/gotests/internal/goparser,github.com/cweill/gotests/internal/output,github.com/cweill/gotests/internal/models

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,15 +41,9 @@ jobs:
         go get github.com/mattn/goveralls
         go get golang.org/x/tools/cmd/cover
         golang.org/x/mod/module
-      env:
-        GOPATH: ${{ github.workspace }}/go
 
     - name: Test
       run: go test ./...
-      env:
-        GOPATH: ${{ github.workspace }}/go
       
     - name: Coverage
       run: go test -c -covermode=count -coverpkg=github.com/cweill/gotests,github.com/cweill/gotests/internal/input,github.com/cweill/gotests/internal/render,github.com/cweill/gotests/internal/goparser,github.com/cweill/gotests/internal/output,github.com/cweill/gotests/internal/models
-      env:
-        GOPATH: ${{ github.workspace }}/go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,6 +27,7 @@ jobs:
 
     - name: Get dependencies
       run: |
+        go get -v -t -d ./...
         go get github.com/mattn/goveralls
         go get golang.org/x/tools/cmd/cover
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,15 +8,19 @@ on:
 
 jobs:
 
-  build:
-    name: Build
-    runs-on: ubuntu-latest
+  test:
+    name: Test
+    strategy:
+      matrix:
+        go-version: [1.9.x, 1.10.x, 1.11.x, 1.12.x, 1.13.x, 1.14.x, 1.15.x]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     steps:
 
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.13
+        go-version: ${{ matrix.go-version }}
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,6 +27,8 @@ jobs:
 
     - name: Get dependencies
       run: |
+        echo $GOPATH
+        echo ${{ github.workspace }}
         go get -v -t -d ./...
         go get github.com/mattn/goveralls
         go get golang.org/x/tools/cmd/cover

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,41 @@
+name: Go
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+        go get github.com/mattn/goveralls
+        go get github.com/golang/tools/cmd/cover
+        if [ -f Gopkg.toml ]; then
+            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            dep ensure
+        fi
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...
+      
+    - name: Coverage
+      run: go test -c -covermode=count -coverpkg=github.com/cweill/gotests,github.com/cweill/gotests/internal/input,github.com/cweill/gotests/internal/render,github.com/cweill/gotests/internal/goparser,github.com/cweill/gotests/internal/output,github.com/cweill/gotests/internal/models

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
       GO111MODULE: auto
     defaults:
       run:
-        working-directory: ${{ env.GOPATH }}/src/github.com/cweill/gotests
+        working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
     steps:
 
     - name: Set up Go 1.x
@@ -31,7 +31,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
       with:
-        path: src/github.com/cweill/gotests
+        path: src/github.com/${{ github.repository }}
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,12 +28,12 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
 
-    - name: Check out code into the Go module directory
+    - name: Check Out code
       uses: actions/checkout@v2
       with:
         path: src/github.com/cweill/gotests
 
-    - name: Get dependencies
+    - name: Get Dependencies
       run: |
         go get github.com/mattn/goveralls
         if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
@@ -43,4 +43,11 @@ jobs:
       run: go test ./...
       
     - name: Coverage
-      run: go test -c -covermode=count -coverpkg=github.com/cweill/gotests,github.com/cweill/gotests/internal/input,github.com/cweill/gotests/internal/render,github.com/cweill/gotests/internal/goparser,github.com/cweill/gotests/internal/output,github.com/cweill/gotests/internal/models
+      run: |
+        go test -c -covermode=count -coverpkg=github.com/cweill/gotests,github.com/cweill/gotests/internal/input,github.com/cweill/gotests/internal/render,github.com/cweill/gotests/internal/goparser,github.com/cweill/gotests/internal/output,github.com/cweill/gotests/internal/models
+        ./gotests.test -test.coverprofile coverage.cov
+        
+    - name: Send Coverate Report
+      run: $GOPATH/bin/goveralls -coverprofile=coverage.cov -service=github
+      env:
+        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Get dependencies
       run: |
         go get github.com/mattn/goveralls
-        go get github.com/golang/tools/cmd/cover
+        go get golang.org/x/tools/cmd/cover
         
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,6 +15,8 @@ jobs:
         go-version: [1.9.x, 1.10.x, 1.11.x, 1.12.x, 1.13.x, 1.14.x, 1.15.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
+    env:
+      GOPATH: $GITHUB_WORKSPACE/go
     steps:
 
     - name: Set up Go 1.x
@@ -25,14 +27,12 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:
-        path: ${{ matrix.go-version }}/src/cweill/
+        path: go/src/github.com/cweill/gotests
 
     - name: Get dependencies
       run: |
-        echo $GOPATH
+        echo Gopath: $GOPATH
         echo Workspace: ${{ github.workspace }}
-        echo Repo: ${{ github.repository }}
-        go get -v -t -d ./...
         go get github.com/mattn/goveralls
         go get golang.org/x/tools/cmd/cover
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         go get github.com/mattn/goveralls
         go get github.com/tools/cmd/cover || go get golang.org/x/tools/cmd/cover
-        go get golang.org/x/mod
+        go get -v ./...
 
     - name: Test
       run: go test ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,14 +23,9 @@ jobs:
 
     - name: Get dependencies
       run: |
-        go get -v -t -d ./...
         go get github.com/mattn/goveralls
         go get github.com/golang/tools/cmd/cover
-        if [ -f Gopkg.toml ]; then
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-            dep ensure
-        fi
-
+        
     - name: Build
       run: go build -v ./...
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,12 +28,12 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
 
-    - name: Check Out code
+    - name: Check out code
       uses: actions/checkout@v2
       with:
         path: src/github.com/cweill/gotests
 
-    - name: Get Dependencies
+    - name: Get dependencies
       run: |
         go get github.com/mattn/goveralls
         if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
@@ -42,12 +42,12 @@ jobs:
     - name: Test
       run: go test ./...
       
-    - name: Coverage
+    - name: Get Coverage Report
       run: |
         go test -c -covermode=count -coverpkg=github.com/cweill/gotests,github.com/cweill/gotests/internal/input,github.com/cweill/gotests/internal/render,github.com/cweill/gotests/internal/goparser,github.com/cweill/gotests/internal/output,github.com/cweill/gotests/internal/models
         ./gotests.test -test.coverprofile coverage.cov
         
-    - name: Send Coverate Report
+    - name: Send Coverage Report
       run: $GOPATH/bin/goveralls -coverprofile=coverage.cov -service=github
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,6 +24,8 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+      with:
+        path: ${{ matrix.go-version }}/src/cweill/
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [1.9.x, 1.10.x]
+        go-version: [1.9.x, 1.10.x, 1.11.x, 1.12.x, 1.13.x, 1.14.x, 1.15.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     env:
@@ -36,7 +36,7 @@ jobs:
     - name: Get dependencies
       run: |
         go get github.com/mattn/goveralls
-        go get github.com/tools/cmd/cover || go get golang.org/x/tools/cmd/cover
+        if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
         go get -v ./...
 
     - name: Test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [1.9.x, 1.10.x, 1.11.x, 1.12.x, 1.13.x, 1.14.x, 1.15.x]
+        go-version: [1.9.x, 1.10.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -30,6 +30,7 @@ jobs:
     - name: Get dependencies
       run: |
         echo Gopath: $GOPATH
+        echo ls $GOPATH/src/github.com/cweill/gotests
         echo Workspace: ${{ github.workspace }}
         go get github.com/mattn/goveralls
         go get golang.org/x/tools/cmd/cover

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,8 @@ jobs:
     - name: Get dependencies
       run: |
         echo $GOPATH
-        echo ${{ github.workspace }}
+        echo Workspace: ${{ github.workspace }}
+        echo Repo: ${{ github.repository }}
         go get -v -t -d ./...
         go get github.com/mattn/goveralls
         go get golang.org/x/tools/cmd/cover

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,12 +35,8 @@ jobs:
 
     - name: Get dependencies
       run: |
-        echo Gopath: $GOPATH
-        echo `ls $GOPATH/src/github.com/cweill/gotests`
-        echo Workspace: ${{ github.workspace }}
         go get github.com/mattn/goveralls
-        go get golang.org/x/tools/cmd/cover
-        golang.org/x/mod/module
+        go get github.com/tools/cmd/cover || go get golang.org/x/tools/cmd/cover
 
     - name: Test
       run: go test ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,6 +15,12 @@ jobs:
         go-version: [1.9.x, 1.10.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
+    env:
+      GOPATH: ${{ github.workspace }}
+      GO111MODULE: auto
+    defaults:
+      run:
+        working-directory: ${{ env.GOPATH }}/src/github.com/cweill/gotests
     steps:
 
     - name: Set up Go 1.x
@@ -25,12 +31,12 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:
-        path: go/src/github.com/cweill/gotests
+        path: src/github.com/cweill/gotests
 
     - name: Get dependencies
       run: |
         echo Gopath: $GOPATH
-        echo ls $GOPATH/src/github.com/cweill/gotests
+        echo `ls $GOPATH/src/github.com/cweill/gotests`
         echo Workspace: ${{ github.workspace }}
         go get github.com/mattn/goveralls
         go get golang.org/x/tools/cmd/cover

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,8 +15,6 @@ jobs:
         go-version: [1.9.x, 1.10.x, 1.11.x, 1.12.x, 1.13.x, 1.14.x, 1.15.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
-    env:
-      GOPATH: $GITHUB_WORKSPACE/go
     steps:
 
     - name: Set up Go 1.x
@@ -35,9 +33,15 @@ jobs:
         echo Workspace: ${{ github.workspace }}
         go get github.com/mattn/goveralls
         go get golang.org/x/tools/cmd/cover
+      env:
+        GOPATH: ${{ github.workspace }}/go
 
     - name: Test
       run: go test ./...
+      env:
+        GOPATH: ${{ github.workspace }}/go
       
     - name: Coverage
       run: go test -c -covermode=count -coverpkg=github.com/cweill/gotests,github.com/cweill/gotests/internal/input,github.com/cweill/gotests/internal/render,github.com/cweill/gotests/internal/goparser,github.com/cweill/gotests/internal/output,github.com/cweill/gotests/internal/models
+      env:
+        GOPATH: ${{ github.workspace }}/go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,6 +37,7 @@ jobs:
       run: |
         go get github.com/mattn/goveralls
         go get github.com/tools/cmd/cover || go get golang.org/x/tools/cmd/cover
+        go get golang.org/x/mod
 
     - name: Test
       run: go test ./...


### PR DESCRIPTION
This addresses #143.

All the CI steps that were in Travis should now work in GitHub actions. The trickiest part was to make 1.9 ans 1.10 work -- Travis CI does some extra steps to workaround GOPATH. 

I've also added Go 1.14 and 1.15 just for the sake of CI tests -- they should be working. 

I've verified the coverage reports on the coveralls, but I'm not sure how to actually test the badge.