### PR TITLE
Add version command

### DIFF
--- a/gotests.go
+++ b/gotests.go
@@ -30,6 +30,7 @@ type Options struct {
 	TemplateDir    string                 // Path to custom template set
 	TemplateParams map[string]interface{} // Custom external parameters
 	TemplateData   [][]byte               // Data slice for templates
+	Version        bool                   // Show version of gotests installed
 }
 
 // A GeneratedTest contains information about a test file with generated tests.

--- a/gotests/main.go
+++ b/gotests/main.go
@@ -60,6 +60,7 @@ var (
 	template           = flag.String("template", "", `optional. Specify custom test code templates, e.g. testify. This can also be set via environment variable GOTESTS_TEMPLATE`)
 	templateParamsPath = flag.String("template_params_file", "", "read external parameters to template by json with file")
 	templateParams     = flag.String("template_params", "", "read external parameters to template by json with stdin")
+	version            = flag.Bool("version", false, "current version of gotests ")
 )
 
 var (
@@ -92,6 +93,7 @@ func main() {
 		Template:           valOrGetenv(*template, "GOTESTS_TEMPLATE"),
 		TemplateDir:        valOrGetenv(*templateDir, "GOTESTS_TEMPLATE_DIR"),
 		TemplateParamsPath: *templateParamsPath,
+		Version:            *version,
 	})
 }
 

--- a/gotests/process/process.go
+++ b/gotests/process/process.go
@@ -15,6 +15,7 @@ import (
 )
 
 const newFilePerm os.FileMode = 0644
+const versionNumber = "v1.6.1"
 
 const (
 	specifyFlagMessage = "Please specify either the -only, -excl, -exported, or -all flag"
@@ -36,6 +37,7 @@ type Options struct {
 	TemplateDir        string   // Path to custom template set
 	TemplateParamsPath string   // Path to custom parameters json file(s).
 	TemplateData       [][]byte // Data slice for templates
+	Version            bool     // Print version number of gotests being used
 }
 
 // Generates tests for the Go files defined in args with the given options.
@@ -58,7 +60,15 @@ func Run(out io.Writer, args []string, opts *Options) {
 	}
 }
 
+func versionMessage() string {
+	return fmt.Sprintf("gotests version %s", versionNumber)
+}
+
 func parseOptions(out io.Writer, opt *Options) *gotests.Options {
+	if opt.Version {
+		fmt.Fprintln(out, versionMessage())
+		return nil
+	}
 	if opt.OnlyFuncs == "" && opt.ExclFuncs == "" && !opt.ExportedFuncs && !opt.AllFuncs {
 		fmt.Fprintln(out, specifyFlagMessage)
 		return nil
@@ -102,6 +112,7 @@ func parseOptions(out io.Writer, opt *Options) *gotests.Options {
 		TemplateDir:    opt.TemplateDir,
 		TemplateParams: templateParams,
 		TemplateData:   opt.TemplateData,
+		Version:        opt.Version,
 	}
 }
 

--- a/gotests/process/process_test.go
+++ b/gotests/process/process_test.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 )
 
@@ -48,6 +49,11 @@ func TestRun(t *testing.T) {
 			args: []string{"testdata/foobar.go"},
 			opts: &Options{ExclFuncs: "??"},
 			want: "Invalid -excl regex: error parsing regexp: missing argument to repetition operator: `??`\n",
+		}, {
+			name: "Version option",
+			args: []string{},
+			opts: &Options{Version: true},
+			want: fmt.Sprintf("%s\n", versionMessage()),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Adding version command to show current version of gotests installed. 

**NOTE** Had issue with tests failing intermittently locally (even on develop). Not sure what the issue, please let me know if this is a known issue or something I should make another ticket for. This only appears to be happening for the 1.16.x build. 

#133 