### PR TITLE
return on wantErr bypass Subtests

### DIFF
--- a/internal/render/templates/function.tmpl
+++ b/internal/render/templates/function.tmpl
@@ -69,6 +69,9 @@ func {{.TestName}}(t *testing.T) {
 				if {{if .OnlyReturnsError}} err := {{template "call" $f}}; {{end}} (err != nil) != tt.wantErr {
 					t.Errorf("{{template "message" $f}} error = %v, wantErr %v", {{template "inputs" $f}} err, tt.wantErr)
 					{{- if .TestResults}}
+						if tt.wantErr {
+							return
+						}
 						{{if .Subtests }}return{{else}}continue{{end}}
 					{{- end}}
 				}


### PR DESCRIPTION
Thanks for your contribution. When I am generating test if the function has error then we add a test for `wantErr` then adds `Subtests`. But there should be a return statement also and return if `wantErr` e.g

```go
t.Run(tt.name, func(t *testing.T) {
	got, err := tt.p.Write(tt.args.record)
	if (err != nil) != tt.wantErr {
		t.Errorf("parquetWriter.Write() error = %v, wantErr %v", err, tt.wantErr)
		return
	}
        //////////////////// this return should be added//////////////////////////
	if tt.wantErr {
		return
	}
        //////////////////// this return should be added//////////////////////////
        
       // There is no point checking Subtests if I want error it may create wrong test result
	if got != tt.want {
		t.Errorf("parquetWriter.Write() = %v, want %v", got, tt.want)
	}
})
```