### PR TITLE
[docs] update README to include git install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ __Minimum Go version:__ Go 1.6
 Use [`go get`](https://golang.org/cmd/go/#hdr-Download_and_install_packages_and_dependencies) to install and update:
 
 ```sh
+# using Go version < 1.17
 $ go get -u github.com/cweill/gotests/...
+# using Go version => 1.17
+go install github.com/cweill/gotests/...@latest
 ```
 
 ## Usage


### PR DESCRIPTION
Using go get -u github.com/cweill/gotests/... to install would give following error message.
```
go get: installing executables with 'go get' in module mode is deprecated.
	Use 'go install pkg@version' instead.
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

Instruction to use go install is added to README for Go version >= 1.17.