### PR TITLE
Update readme for golang 1.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ __Minimum Go version:__ Go 1.6
 Use [`go get`](https://golang.org/cmd/go/#hdr-Download_and_install_packages_and_dependencies) to install and update:
 
 ```sh
-$ go get -u github.com/cweill/gotests/...
+$ go install github.com/cweill/gotests/...@latest
 ```
 
 ## Usage


### PR DESCRIPTION
Current code shows this error
```ssh
$ go get -u github.com/cweill/gotests/...
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```