### PR TITLE
update README for `go install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ The following shows `gotests` in action using the [official Sublime Text 3 plugi
 
 __Minimum Go version:__ Go 1.6
 
-Use [`go get`](https://golang.org/cmd/go/#hdr-Download_and_install_packages_and_dependencies) to install and update:
-
+Use [`go install`](https://pkg.go.dev/cmd/go#hdr-Compile_and_install_packages_and_dependencies) to install and update:
 ```sh
-$ go get -u github.com/cweill/gotests/...
+$ go install github.com/cweill/gotests/gotests@latest
 ```
 
 ## Usage


### PR DESCRIPTION
`go get` is no longer supported; use `go install`